### PR TITLE
Replace base R merge() with dplyr tidy joins in functions/

### DIFF
--- a/functions/helper_functions.R
+++ b/functions/helper_functions.R
@@ -106,7 +106,8 @@
     summarize(crosswalk_states = paste(unique(stusps), collapse = ","))
   
   # merging back
-  sab_t <- merge(sab_t, pwsid_state_summary, by = "pwsid", all.x = T) %>%
+  sab_t <- sab_t %>%
+    left_join(pwsid_state_summary, by = "pwsid") %>%
     relocate(crosswalk_states, .after = state)
   
   return(sab_t)
@@ -510,8 +511,8 @@ update_data_summary <- function(dataset_name, raw_s3_link, clean_s3_link){
     select(dataset, all_of(dont_touch_these_columns))
   
   # merge them together to create the updated row
-  updated_row <- merge(task_manger_simple, 
-                       task_manager_df, by = "dataset") %>%
+  updated_row <- task_manger_simple %>%
+    inner_join(task_manager_df, by = "dataset") %>%
     mutate(across(everything(), ~ as.character(.)))
   
   # bind this row back to the task manager

--- a/functions/sabs_blocks_exploration.R
+++ b/functions/sabs_blocks_exploration.R
@@ -34,7 +34,8 @@ sdwis_pop <- water_sys$epa_sabs
 ################################################################################
 # merging to filter epa_sabs_geoms such that it's not running an intersection 
 # on the whole dataset
-epa_sabs <- merge(epa_sabs_pwsids, epa_sabs_geoms, by = "pwsid") %>% 
+epa_sabs <- epa_sabs_pwsids %>%
+  inner_join(epa_sabs_geoms, by = "pwsid") %>%
   st_as_sf()
 
 # states to loop through- removing ones that intersect multiple states: 
@@ -103,8 +104,8 @@ less_30_blocks_geoms <- epa_sabs %>%
   filter(pwsid %in% less_30_blocks$pwsid)
 
 # I also want the block intersection number
-less_30_blocks_geoms_f <- merge(less_30_blocks_geoms, 
-                                less_30_blocks, by = "pwsid")
+less_30_blocks_geoms_f <- less_30_blocks_geoms %>%
+  inner_join(less_30_blocks, by = "pwsid")
 intersect_pal <- colorNumeric(
   palette = cont_palette(5),
   domain = less_30_blocks_geoms_f$total_intersected_blocks)
@@ -150,7 +151,8 @@ leaflet() %>%
 # look at relationships between block overlap & pop estimates  ################
 xwalk_pop <- xwalk %>% select(pwsid, total_pop, tier_crosswalk)
 # merging with other dataset
-pop_comps <- merge(summary_final, sdwis_pop) %>%
+pop_comps <- summary_final %>%
+  inner_join(sdwis_pop) %>%
   select(pwsid, epic_states_intersect, 
          population_served_count, total_intersected_blocks) %>%
   rename(sdwis_pop = population_served_count) %>%

--- a/functions/update_task_manager.R
+++ b/functions/update_task_manager.R
@@ -24,9 +24,9 @@ dont_touch_these_columns <- setdiff(names(task_manager_enviro),
 task_manger_simple <- task_manager_enviro %>% 
   select(dataset, all_of(dont_touch_these_columns))
 
-# merge them together to add the updated columns 
-updated_cols <- merge(task_manger_simple, 
-                      manual_task_manager_updates, by = "dataset") %>%
+# merge them together to add the updated columns
+updated_cols <- task_manger_simple %>%
+  inner_join(manual_task_manager_updates, by = "dataset") %>%
   mutate(across(everything(), ~ as.character(.))) %>%
   # do some quick reorg
   relocate(update_freq, .after = dataset) %>%
@@ -126,12 +126,9 @@ dont_touch_these_columns <- setdiff(names(data_inventory_gs),
 data_inventory_dont_touch <- data_inventory_gs %>% 
   select(list, dataset, variable, all_of(dont_touch_these_columns))
 
-# merge them together to add the updated columns 
-updated_data_inventory <- merge(data_inventory_dont_touch, 
-                                results_f, 
-                                by = c("list", "dataset", "variable"), 
-                                all = T, 
-                                sort = F) %>%
+# merge them together to add the updated columns
+updated_data_inventory <- data_inventory_dont_touch %>%
+  full_join(results_f, by = c("list", "dataset", "variable")) %>%
   mutate(across(everything(), ~ as.character(.))) 
 
 # I also want to add a flag for new columns (in results_f, but not data inventory), 

--- a/functions/xwalk_census_geo_sabs.R
+++ b/functions/xwalk_census_geo_sabs.R
@@ -133,7 +133,7 @@ xwalk_census_geo_sabs <- function(sabs, sf_data_census, interp_methods,
     group_by(pwsid) %>%
     summarize(overlap_states = paste0(unique(stusps), collapse = ", ")) 
   
-  sab_t <- merge(sab_t, pwsid_state_flag, by = "pwsid", all.x = T)
+  sab_t <- sab_t %>% left_join(pwsid_state_flag, by = "pwsid")
   
   # states to loop through: 
   unique_states <- str_sort(unique(unlist(str_split(sab_t$overlap_states, ",")))) %>%
@@ -158,12 +158,12 @@ xwalk_census_geo_sabs <- function(sabs, sf_data_census, interp_methods,
     relocate(state_code_function)
   
   # translating state codes to state abbreviations
-  sf_data_census_tidy_codes <- merge(sf_data_census_tidy, tigris::fips_codes %>% 
-                                       select(state, state_code) %>% 
-                                       unique() %>%
-                                       rename(state_function = state), 
-                                     by.x = "state_code_function", 
-                                     by.y = "state_code", all.x = T) %>%
+  sf_data_census_tidy_codes <- sf_data_census_tidy %>%
+    left_join(tigris::fips_codes %>%
+                select(state, state_code) %>%
+                unique() %>%
+                rename(state_function = state),
+              by = c("state_code_function" = "state_code")) %>%
     relocate(state_function)
 
   ##############################################################################

--- a/functions/xwalk_census_vars_sabs.R
+++ b/functions/xwalk_census_vars_sabs.R
@@ -494,8 +494,8 @@ xwalk_census_vars_sabs <- function(sab_f, acs_year, census_var_sheet, save_data 
   
   # merging census stats with crosswalk - pwsi.ds that exist outside of the 
   # state but have state == "state abbr" will be dropped here 
-  pwsid_xwalk <- merge(census_wide, pwsid_cross, 
-                       by.x = "GEOID", by.y = "tract_geoid", all.y = T)
+  pwsid_xwalk <- census_wide %>%
+    right_join(pwsid_cross, by = c("GEOID" = "tract_geoid"))
   
   # multiplying all extensive vars by tract weights: 
   pwsid_weight_xwalk <- pwsid_xwalk %>%
@@ -528,8 +528,8 @@ xwalk_census_vars_sabs <- function(sab_f, acs_year, census_var_sheet, save_data 
   
 
   # merging back with original: 
-  pwsid_xwalk <- merge(pwsid_weighted_xwalk, pwsid_weighted_inc, 
-                       by = "pwsid", all.x = T) %>%
+  pwsid_xwalk <- pwsid_weighted_xwalk %>%
+    left_join(pwsid_weighted_inc, by = "pwsid") %>%
     mutate(tier_crosswalk = "tier_2_xwalk")
   
   


### PR DESCRIPTION
Closes #5

## What and Why

Base R `merge()` works, but you have to read the `all`, `all.x`, and `all.y` flags to figure out what kind of join is happening. The rest of this codebase already uses tidyverse (`mutate`, `filter`, `select`, pipes), so `merge()` sticks out.

dplyr's named join functions make the intent visible in the function name itself, and perform better on larger datasets.

## Scope

Scoped to the `functions/` folder only (5 files, 11 call sites). Worker files in `1_downloaders/` follow the same pattern and are candidates for a follow-up issue once this approach is confirmed.

## Mapping applied

| `merge()` args | Replaced with |
|---|---|
| no `all` flag | `inner_join` - keep only rows that match in both tables |
| `all.x = T` | `left_join` - keep all rows from left, NA where right has no match |
| `all.y = T` | `right_join` - keep all rows from right, NA where left has no match |
| `all = T` | `full_join` - keep all rows from both tables |
| `by.x` / `by.y` | `by = c("col_x" = "col_y")` named vector syntax |

## Behaviour

No logic changes - output is identical for all 11 replacements. The `sort = F` argument on the one `full_join` was dropped since dplyr joins don't sort by default, which matches the intended behaviour.