### PR TITLE
Add cartographic boundaries yearly worker

### DIFF
--- a/1_downloaders/yearly/cartographic_boundaries_worker/Dockerfile
+++ b/1_downloaders/yearly/cartographic_boundaries_worker/Dockerfile
@@ -1,0 +1,29 @@
+FROM rocker/rstudio:latest
+
+RUN mkdir -p /home/epic
+WORKDIR /home/epic
+
+# required for sf dependencies
+RUN apt-get update && apt-get install -y \
+    libudunits2-dev \
+    libgdal-dev \
+    libgeos-dev \
+    libproj-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install required R packages from CRAN
+RUN install2.r --error \
+    tidyverse \
+    janitor \
+    aws.s3 \
+    sf
+
+# Copy the R script
+ADD cartographic_boundaries_yearly.R /home/epic/
+
+# Expose ports
+EXPOSE 2000 2001
+
+# Set the working directory and command to run the file
+WORKDIR /home/epic
+CMD R -e "source('./cartographic_boundaries_yearly.R')"

--- a/1_downloaders/yearly/cartographic_boundaries_worker/cartographic_boundaries_yearly.R
+++ b/1_downloaders/yearly/cartographic_boundaries_worker/cartographic_boundaries_yearly.R
@@ -1,0 +1,291 @@
+###############################################################################
+# Cartographic Boundaries Yearly Worker
+# Downloads US Census Bureau cartographic boundary shapefiles (states, counties,
+# and places) from the GENZ archive, runs light QA/QC checks, and pushes the
+# ZIPs to raw, clean, and staging buckets in S3. These files support search
+# functionality in the front-end app.
+#
+# Year is configurable via the CB_YEAR environment variable (default: "2022").
+# Source format is the Census Bureau's 500k-scale (1:500,000) shapefile ZIPs:
+#   https://www2.census.gov/geo/tiger/GENZ{YEAR}/shp/cb_{YEAR}_us_{layer}_500k.zip
+###############################################################################
+
+# libraries needed:
+library(tidyverse)
+library(aws.s3)
+library(janitor)
+library(sf)
+
+# no scientific notation
+options(scipen = 999)
+
+# make sure to specify the correct bucket region for IAM role:
+Sys.setenv("AWS_DEFAULT_REGION" = 'us-east-1')
+
+# for logs:
+print("I'm running!")
+
+###############################################################################
+# Config
+###############################################################################
+CB_YEAR <- Sys.getenv("CB_YEAR", unset = "2022")
+print(paste0("Pulling Census Bureau cartographic boundaries for year: ", CB_YEAR))
+
+# Per-layer config. expected_min_rows / expected_max_rows form a sanity range
+# used in QA/QC; counts come from real 2022 data plus headroom.
+LAYERS <- list(
+  state = list(
+    expected_min_rows = 50,     # 50 states (DC + territories may also be present)
+    expected_max_rows = 100
+  ),
+  county = list(
+    expected_min_rows = 3000,   # ~3,140 in real census data
+    expected_max_rows = 5000
+  ),
+  place = list(
+    expected_min_rows = 25000,  # ~30,000+ in real census data
+    expected_max_rows = 50000
+  )
+)
+
+# Fill in URLs and file names for the requested year
+for (lyr in names(LAYERS)) {
+  LAYERS[[lyr]]$file_name <- sprintf("cb_%s_us_%s_500k.zip", CB_YEAR, lyr)
+  LAYERS[[lyr]]$shp_name  <- sprintf("cb_%s_us_%s_500k.shp", CB_YEAR, lyr)
+  LAYERS[[lyr]]$url       <- sprintf(
+    "https://www2.census.gov/geo/tiger/GENZ%s/shp/%s",
+    CB_YEAR, LAYERS[[lyr]]$file_name
+  )
+}
+
+dataset_i   <- "cartographic_boundaries"
+raw_base     <- "s3://tech-team-data/national-dw-tool/raw/national/cartographic-boundaries"
+clean_base   <- "s3://tech-team-data/national-dw-tool/clean/national/cartographic-boundaries"
+staging_base <- "s3://tech-team-data/national-dw-tool/test-staged/cartographic-boundaries"
+
+###############################################################################
+# Read task manager
+###############################################################################
+task_manager <- aws.s3::s3read_using(read.csv,
+  object = "s3://tech-team-data/national-dw-tool/task_manager_data_summary.csv") |>
+  mutate(across(everything(), ~ as.character(.)))
+
+###############################################################################
+# Failure helper: write "WORKER FAILED" row to task manager and quit. Mirrors
+# the pattern in me_daily.R and awia_quarterly.R.
+###############################################################################
+abort_with_failure <- function(msg) {
+  message("FAILURE: ", msg)
+  print("Updating task manager with failure status and shutting down")
+
+  task_manager_df <- data.frame(
+    dataset = dataset_i,
+    date_downloaded = Sys.Date(),
+    raw_link   = "WORKER FAILED - SEE LOGS",
+    clean_link = "WORKER FAILED - SEE LOGS"
+  )
+
+  if (!(dataset_i %in% task_manager$dataset)) {
+    task_manager <- bind_rows(task_manager, data.frame(dataset = dataset_i))
+  }
+
+  dont_touch_these_columns <- setdiff(names(task_manager), names(task_manager_df))
+  task_manger_simple <- task_manager |>
+    select(dataset, all_of(dont_touch_these_columns))
+
+  updated_row <- task_manger_simple |>
+    inner_join(task_manager_df, by = "dataset") |>
+    mutate(across(everything(), ~ as.character(.)))
+
+  updated_task_manager <- task_manager |>
+    filter(dataset != dataset_i) |>
+    bind_rows(updated_row) |>
+    arrange(dataset)
+
+  tmp <- tempfile()
+  write.csv(updated_task_manager, file = paste0(tmp, ".csv"), row.names = FALSE)
+  on.exit(unlink(tmp), add = TRUE)
+  put_object(
+    file = paste0(tmp, ".csv"),
+    object = "s3://tech-team-data/national-dw-tool/task_manager_data_summary.csv",
+    acl = "public-read"
+  )
+
+  print("Update to Task Manager Complete - Shutting Down")
+  quit(save = "no")
+}
+
+###############################################################################
+# Part 1: download all three ZIP files
+###############################################################################
+print("Downloading cartographic boundary ZIPs from census.gov")
+# Bump the default timeout because the place layer is ~70MB
+options(timeout = max(600, getOption("timeout")))
+
+tmp_dir <- tempdir()
+
+for (lyr in names(LAYERS)) {
+  info <- LAYERS[[lyr]]
+  local_zip <- file.path(tmp_dir, info$file_name)
+  LAYERS[[lyr]]$local_zip <- local_zip
+
+  print(sprintf("  %s -> %s", lyr, info$url))
+  ok <- tryCatch({
+    download.file(info$url, local_zip, mode = "wb", quiet = TRUE)
+    TRUE
+  }, error = function(e) {
+    message("Download error for ", lyr, ": ", conditionMessage(e))
+    FALSE
+  })
+
+  if (!ok || !file.exists(local_zip) || file.info(local_zip)$size == 0) {
+    abort_with_failure(sprintf(
+      "Failed to download layer '%s' from %s. Year %s may not exist on census.gov.",
+      lyr, info$url, CB_YEAR
+    ))
+  }
+  print(sprintf("    downloaded %.1f MB", file.info(local_zip)$size / 1024 / 1024))
+}
+
+###############################################################################
+# Part 2: QA/QC checks (interim - see issue #22 for the broader framework)
+###############################################################################
+print("Running QA/QC checks")
+
+for (lyr in names(LAYERS)) {
+  info <- LAYERS[[lyr]]
+  print(sprintf("  Checking %s", lyr))
+
+  # Extract into a layer-specific subdir
+  extract_dir <- file.path(tmp_dir, paste0("extract_", lyr))
+  dir.create(extract_dir, showWarnings = FALSE, recursive = TRUE)
+
+  unzip_files <- tryCatch(
+    unzip(info$local_zip, exdir = extract_dir),
+    error = function(e) NULL
+  )
+  if (is.null(unzip_files) || length(unzip_files) == 0) {
+    abort_with_failure(sprintf("Unzip failed for layer '%s'", lyr))
+  }
+
+  shp_path <- file.path(extract_dir, info$shp_name)
+  if (!file.exists(shp_path)) {
+    abort_with_failure(sprintf(
+      "Expected shapefile '%s' not found in zip for layer '%s'",
+      info$shp_name, lyr
+    ))
+  }
+
+  sf_obj <- tryCatch(
+    sf::st_read(shp_path, quiet = TRUE),
+    error = function(e) {
+      message("st_read error: ", conditionMessage(e))
+      NULL
+    }
+  )
+  if (is.null(sf_obj)) {
+    abort_with_failure(sprintf("Could not read shapefile for layer '%s'", lyr))
+  }
+
+  n_rows <- nrow(sf_obj)
+  print(sprintf("    rows: %d (expected range [%d, %d])",
+                n_rows, info$expected_min_rows, info$expected_max_rows))
+  if (n_rows < info$expected_min_rows || n_rows > info$expected_max_rows) {
+    abort_with_failure(sprintf(
+      "Row count for '%s' is %d, outside expected range [%d, %d]",
+      lyr, n_rows, info$expected_min_rows, info$expected_max_rows
+    ))
+  }
+
+  invalid_count <- sum(!sf::st_is_valid(sf_obj))
+  print(sprintf("    invalid geometries: %d", invalid_count))
+  if (invalid_count > 0) {
+    abort_with_failure(sprintf(
+      "Layer '%s' has %d invalid geometries", lyr, invalid_count
+    ))
+  }
+
+  print(sprintf("    %s OK", lyr))
+}
+
+print("All QA/QC checks passed")
+
+###############################################################################
+# Part 3: upload ZIPs to raw, clean, and staging
+###############################################################################
+print("Uploading to S3 (raw, clean, staging)")
+
+raw_links     <- c()
+clean_links   <- c()
+staging_links <- c()
+
+for (lyr in names(LAYERS)) {
+  info <- LAYERS[[lyr]]
+
+  raw_obj     <- file.path(raw_base,     info$file_name)
+  clean_obj   <- file.path(clean_base,   info$file_name)
+  staging_obj <- file.path(staging_base, info$file_name)
+
+  print(sprintf("  %s", info$file_name))
+
+  # Raw: pristine source ZIP, archival
+  put_object(file = info$local_zip, object = raw_obj)
+  # Clean: same ZIP passthrough (no transformation needed - per EmmaLi on #23)
+  put_object(file = info$local_zip, object = clean_obj)
+  # Staging: same ZIP, publicly readable for front-end consumption
+  put_object(file = info$local_zip, object = staging_obj, acl = "public-read")
+
+  raw_links     <- c(raw_links,     raw_obj)
+  clean_links   <- c(clean_links,   clean_obj)
+  staging_links <- c(staging_links, staging_obj)
+}
+
+###############################################################################
+# Part 4: update task manager (multi-file "Multiple - ..." pattern like SDWA)
+###############################################################################
+print("Updating Task Manager")
+
+raw_link_combined     <- paste0("Multiple - ", paste(raw_links,     collapse = "; "))
+clean_link_combined   <- paste0("Multiple - ", paste(clean_links,   collapse = "; "))
+staged_link_combined  <- paste0("Multiple - ", paste(staging_links, collapse = "; "))
+
+# This worker also pushes to the staged bucket (front-end reads from there
+# directly for cartographic data), so fill in date_staged, staged_link, and
+# data_qual_score in the task manager too.
+task_manager_df <- data.frame(
+  dataset           = dataset_i,
+  date_downloaded   = Sys.Date(),
+  raw_link          = raw_link_combined,
+  clean_link        = clean_link_combined,
+  date_staged       = Sys.Date(),
+  staged_link       = staged_link_combined,
+  data_qual_score   = "all checks passed (download / unzip / row count range / geometry validity, per layer)"
+)
+
+if (!(dataset_i %in% task_manager$dataset)) {
+  task_manager <- bind_rows(task_manager, data.frame(dataset = dataset_i))
+}
+
+dont_touch_these_columns <- setdiff(names(task_manager), names(task_manager_df))
+task_manger_simple <- task_manager |>
+  select(dataset, all_of(dont_touch_these_columns))
+
+updated_row <- task_manger_simple |>
+  inner_join(task_manager_df, by = "dataset") |>
+  mutate(across(everything(), ~ as.character(.)))
+
+updated_task_manager <- task_manager |>
+  filter(dataset != dataset_i) |>
+  bind_rows(updated_row) |>
+  arrange(dataset)
+
+tmp <- tempfile()
+write.csv(updated_task_manager, file = paste0(tmp, ".csv"), row.names = FALSE)
+on.exit(unlink(tmp), add = TRUE)
+put_object(
+  file = paste0(tmp, ".csv"),
+  object = "s3://tech-team-data/national-dw-tool/task_manager_data_summary.csv",
+  acl = "public-read"
+)
+
+print("Worker Job Complete - Shutting Down")


### PR DESCRIPTION
Closes #23

## What

Yearly worker that downloads three US Census Bureau cartographic boundary shapefiles (states, counties, places) from the public GENZ archive on `census.gov`, runs light QA/QC checks, and pushes the ZIPs to raw, clean, and staging buckets in S3. These files support search functionality in the front-end and were previously hardcoded in the front-end repo.

## Design choices (per EmmaLi's confirmation on the issue)

| Decision | Choice |
|----------|--------|
| Year parameterization | `Sys.getenv("CB_YEAR", unset = "2022")` |
| Output format | ZIP passthrough (no GeoJSON conversion) so the front-end's existing `ogr2ogr` flow needs only a source URL change |
| QA/QC pattern | Interim `WORKER FAILED - SEE LOGS` per `me_daily.R`. Will be retrofitted when #22's framework lands. |
| Bucket strategy | Same ZIP written to raw + clean + staging (`test-staged/`); these files don't go through the summarize / UI prep pipeline so the worker promotes them itself |

## QA/QC checks per layer

- HTTP download succeeds and file is non-empty
- Unzip produces the expected `.shp` file
- `sf::st_read` succeeds
- Row count is within a sanity range (states 50-100, counties 3,000-5,000, places 25,000-50,000)
- All geometries pass `sf::st_is_valid`

Any failed check writes `"WORKER FAILED - SEE LOGS"` to the task manager and quits.

## Local validation

Validated end-to-end against the real census.gov endpoint:

```
state:   3.1 MB,  56 rows,    0 invalid geometries
county:  11.1 MB, 3,235 rows, 0 invalid geometries
place:   21.7 MB, 32,466 rows, 0 invalid geometries
```

Failure path tested with `CB_YEAR=9999` (does not exist): aborts on the 404 download as expected.

## Docker build verified

Built the image locally and confirmed:
- All R packages install (`tidyverse`, `janitor`, `aws.s3`, `sf`)
- GDAL 3.8.4 / GEOS 3.12.1 / PROJ 9.4.0 link correctly inside the container
- Worker starts and reaches the expected failure point at the first S3 write attempt

S3 reads/writes and the task manager update were not exercised locally (no AWS credentials), but they mirror the SABs and AWIA patterns already in the repo.

## Note on `aws.ec2metadata`

This worker intentionally omits `aws.ec2metadata`, both the `library()` call and the install in the Dockerfile. While investigating a CRAN install failure during the Docker build, I confirmed via `packageDescription("aws.s3")` that `aws.s3` does not depend on `aws.ec2metadata` (not in Imports, Depends, Suggests, or Enhances). The `library(aws.ec2metadata)` call in the existing workers is effectively a no-op. Verified `aws.s3::s3read_using()` works without it.

This matters now because `aws.ec2metadata` was archived from CRAN on 2026-05-08, so any rebuild of an existing worker would otherwise fail. Full context and reading links in a comment on #23.