### PR TITLE
Add pointblank QA/QC framework, demo on cartographic worker

### DIFF
--- a/1_downloaders/yearly/cartographic_boundaries_worker/Dockerfile
+++ b/1_downloaders/yearly/cartographic_boundaries_worker/Dockerfile
@@ -1,14 +1,28 @@
+# NOTE ON BUILD CONTEXT:
+# This worker sources the shared QA/QC helper at ./functions/checks.R, so the
+# image must be built from the REPO ROOT (not this directory) so that file is
+# in the build context:
+#
+#   docker build -f 1_downloaders/yearly/cartographic_boundaries_worker/Dockerfile \
+#                -t cartographic-boundaries-worker .
+#
+# This is the first worker to depend on a shared functions/ file at build time.
+# dwsrf_worker sources functions/check_env.R and will need the same treatment.
+# Flagged on issue #22 for alignment with the pipeline reorg.
+
 FROM rocker/rstudio:latest
 
-RUN mkdir -p /home/epic
+RUN mkdir -p /home/epic/functions
 WORKDIR /home/epic
 
-# required for sf dependencies
+# system libs: sf needs gdal/geos/proj/udunits; the fs package (pulled in by
+# pointblank's export_report) needs libuv
 RUN apt-get update && apt-get install -y \
     libudunits2-dev \
     libgdal-dev \
     libgeos-dev \
     libproj-dev \
+    libuv1-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Install required R packages from CRAN
@@ -16,10 +30,12 @@ RUN install2.r --error \
     tidyverse \
     janitor \
     aws.s3 \
-    sf
+    sf \
+    pointblank
 
-# Copy the R script
-ADD cartographic_boundaries_yearly.R /home/epic/
+# Copy the worker script and the shared QA/QC helper it sources
+COPY 1_downloaders/yearly/cartographic_boundaries_worker/cartographic_boundaries_yearly.R /home/epic/
+COPY functions/checks.R /home/epic/functions/checks.R
 
 # Expose ports
 EXPOSE 2000 2001

--- a/1_downloaders/yearly/cartographic_boundaries_worker/cartographic_boundaries_yearly.R
+++ b/1_downloaders/yearly/cartographic_boundaries_worker/cartographic_boundaries_yearly.R
@@ -16,6 +16,10 @@ library(aws.s3)
 library(janitor)
 library(sf)
 library(tools)
+library(pointblank)
+
+# shared QA/QC helpers (issue #22)
+source("./functions/checks.R")
 
 # no scientific notation
 options(scipen = 999)
@@ -63,6 +67,11 @@ dataset_i   <- "cartographic_boundaries"
 raw_base     <- "s3://tech-team-data/national-dw-tool/raw/national/cartographic-boundaries"
 clean_base   <- "s3://tech-team-data/national-dw-tool/clean/national/cartographic-boundaries"
 staging_base <- "s3://tech-team-data/national-dw-tool/test-staged/cartographic-boundaries"
+checks_base  <- "s3://tech-team-data/national-dw-tool/checks/cartographic-boundaries"
+
+# single timestamp threaded through check artifacts and the task manager so the
+# CSV, HTML filename, and last_check_run all agree
+run_ts <- Sys.time()
 
 ###############################################################################
 # Read task manager
@@ -149,15 +158,32 @@ for (lyr in names(LAYERS)) {
 }
 
 ###############################################################################
-# Part 2: QA/QC checks (interim - see issue #22 for the broader framework)
+# Part 2: QA/QC checks via pointblank (issue #22)
+#
+# File-level checks (unzip, shapefile present, readable) stay imperative since
+# pointblank validates tables, not files. Once each layer is read into an sf
+# object, the data checks run through the shared pointblank helpers:
+#   - row count within the expected range  -> error (a wrong count means the
+#     download is broken)
+#   - all geometries valid                  -> warning (worth flagging, but one
+#     bad geometry in authoritative census data shouldn't kill the run)
+#   - GEOID column complete (no NAs)        -> error (GEOID is the join key)
+#
+# Each layer's HTML report and results CSV are written to the S3 checks/ dir.
+# If any layer trips an error-level check, the worker aborts after all layers
+# have been checked (so every report is captured for diagnostics).
 ###############################################################################
 print("Running QA/QC checks")
+
+check_summaries <- c()   # per-layer status strings, for the task manager
+check_reports   <- c()   # per-layer report S3 links, for the task manager
+any_check_error <- FALSE
 
 for (lyr in names(LAYERS)) {
   info <- LAYERS[[lyr]]
   print(sprintf("  Checking %s", lyr))
 
-  # Extract into a layer-specific subdir
+  # --- file-level checks (imperative) ---
   extract_dir <- file.path(tmp_dir, paste0("extract_", lyr))
   dir.create(extract_dir, showWarnings = FALSE, recursive = TRUE)
 
@@ -188,28 +214,40 @@ for (lyr in names(LAYERS)) {
     abort_with_failure(sprintf("Could not read shapefile for layer '%s'", lyr))
   }
 
-  n_rows <- nrow(sf_obj)
-  print(sprintf("    rows: %d (expected range [%d, %d])",
-                n_rows, info$expected_min_rows, info$expected_max_rows))
-  if (n_rows < info$expected_min_rows || n_rows > info$expected_max_rows) {
-    abort_with_failure(sprintf(
-      "Row count for '%s' is %d, outside expected range [%d, %d]",
-      lyr, n_rows, info$expected_min_rows, info$expected_max_rows
-    ))
-  }
+  # --- data checks (pointblank) ---
+  # precompute geometry validity as a column, then drop geometry so every check
+  # runs on a plain data frame (pointblank's column checks error on raw sf)
+  attrs <- sf_obj |>
+    mutate(geometry_valid = sf::st_is_valid(sf_obj)) |>
+    sf::st_drop_geometry()
 
-  invalid_count <- sum(!sf::st_is_valid(sf_obj))
-  print(sprintf("    invalid geometries: %d", invalid_count))
-  if (invalid_count > 0) {
-    abort_with_failure(sprintf(
-      "Layer '%s' has %d invalid geometries", lyr, invalid_count
-    ))
-  }
+  agent <- new_check_agent(attrs, label = sprintf("cartographic_boundaries: %s", lyr)) |>
+    check_row_count_range(info$expected_min_rows, info$expected_max_rows, severity = "stop") |>
+    check_column_all_true(geometry_valid, severity = "warning") |>
+    check_column_complete(GEOID, severity = "stop") |>
+    interrogate()
 
-  print(sprintf("    %s OK", lyr))
+  result <- summarize_checks(agent)
+  print(sprintf("    %s: %s", lyr, result$summary))
+
+  # write HTML report + results CSV to S3 checks/ dir
+  report_link <- write_check_artifacts(agent, result$report_df,
+                                       checks_base, tag = lyr, run_ts = run_ts)
+
+  check_summaries <- c(check_summaries, sprintf("%s: %s", lyr, result$summary))
+  check_reports   <- c(check_reports, report_link)
+  if (isTRUE(result$any_error)) any_check_error <- TRUE
 }
 
-print("All QA/QC checks passed")
+# abort if any layer tripped an error-level check (reports already written)
+if (any_check_error) {
+  abort_with_failure(sprintf(
+    "QA/QC error-level failure. Per-layer status: %s",
+    paste(check_summaries, collapse = " | ")
+  ))
+}
+
+print("All QA/QC checks passed (warnings allowed)")
 
 ###############################################################################
 # Part 3: upload ZIPs to raw, clean, and staging
@@ -280,15 +318,22 @@ staged_link_combined  <- paste0("Multiple - ", paste(staging_links, collapse = "
 
 # This worker also pushes to the staged bucket (front-end reads from there
 # directly for cartographic data), so fill in date_staged, staged_link, and
-# data_qual_score in the task manager too.
+# data_qual_score in the task manager too. The QA/QC framework (issue #22) also
+# fills in last_check_run, last_check_status, and last_check_report_link.
+check_status_combined <- paste(check_summaries, collapse = " | ")
+check_report_combined <- paste0("Multiple - ", paste(check_reports, collapse = "; "))
+
 task_manager_df <- data.frame(
-  dataset           = dataset_i,
-  date_downloaded   = Sys.Date(),
-  raw_link          = raw_link_combined,
-  clean_link        = clean_link_combined,
-  date_staged       = Sys.Date(),
-  staged_link       = staged_link_combined,
-  data_qual_score   = "all checks passed (download / unzip / row count range / geometry validity, per layer)"
+  dataset                 = dataset_i,
+  date_downloaded         = Sys.Date(),
+  raw_link                = raw_link_combined,
+  clean_link              = clean_link_combined,
+  date_staged             = Sys.Date(),
+  staged_link             = staged_link_combined,
+  data_qual_score         = check_status_combined,
+  last_check_run          = format(run_ts, "%Y-%m-%dT%H:%M:%S%z"),
+  last_check_status       = check_status_combined,
+  last_check_report_link  = check_report_combined
 )
 
 if (!(dataset_i %in% task_manager$dataset)) {

--- a/functions/checks.R
+++ b/functions/checks.R
@@ -1,0 +1,157 @@
+###############################################################################
+# QA/QC Check Helpers (issue #22)
+# Thin wrappers around the pointblank package that give every worker a
+# consistent way to:
+#   1. run validation checks on a data frame / sf object, with per-check
+#      severity (warning vs error)
+#   2. summarize the results into a short status string and an abort flag
+#   3. write two artifacts to the S3 checks/ directory: pointblank's HTML
+#      report and a CSV of the per-check results
+#
+# Design notes (verified against pointblank 0.12.x):
+# - sf objects: pointblank's column checks (col_vals_*, rows_complete) call
+#   dplyr::mutate() internally, which errors on a raw sf object. For checks
+#   that operate on the whole table (row count, geometry validity) we use
+#   specially(), which receives the table as an argument and avoids that.
+#   For column-level checks, drop the geometry first with st_drop_geometry().
+# - abort decision: use the "S" (stop) column from the agent report, not
+#   all_passed(), because all_passed() also trips on warning-only failures
+#   and would defeat the warn-and-continue behavior.
+###############################################################################
+
+library(pointblank)
+
+# action_levels for a given severity. "stop" fails the worker, "warn" logs and
+# continues. A single failing unit trips the level. Each severity sets only its
+# own threshold so a failing check trips exactly one level (a stop-level failure
+# sets S but not W), which keeps the summary counts unambiguous.
+.check_action_levels <- function(severity = c("stop", "warning")) {
+  severity <- match.arg(severity)
+  if (severity == "stop") {
+    action_levels(stop_at = 1)
+  } else {
+    action_levels(warn_at = 1)
+  }
+}
+
+###############################################################################
+# new_check_agent(data, label)
+# Create a pointblank agent for a data frame or sf object. Add validation
+# steps to the returned agent with the helpers below (or pointblank's own
+# functions), then call interrogate().
+###############################################################################
+new_check_agent <- function(data, label) {
+  create_agent(tbl = data, tbl_name = label, label = label)
+}
+
+###############################################################################
+# check_row_count_range(agent, min_rows, max_rows, severity)
+# Assert the table's row count falls within [min_rows, max_rows]. Uses
+# specially() so it works on sf objects and reports a single validation unit.
+###############################################################################
+check_row_count_range <- function(agent, min_rows, max_rows, severity = "stop") {
+  specially(
+    agent,
+    fn = function(t) {
+      n <- nrow(t)
+      n >= min_rows && n <= max_rows
+    },
+    actions = .check_action_levels(severity),
+    label = sprintf("row_count in [%d, %d]", min_rows, max_rows)
+  )
+}
+
+###############################################################################
+# check_column_complete(agent, column, severity)
+# Assert a column has no missing values (standard pointblank col_vals check).
+# For sf objects, build the agent on st_drop_geometry(sf_obj) first, since
+# pointblank's column checks call dplyr::mutate() which errors on raw sf.
+###############################################################################
+check_column_complete <- function(agent, column, severity = "stop") {
+  col_vals_not_null(
+    agent,
+    columns = {{ column }},
+    actions = .check_action_levels(severity),
+    label = sprintf("%s is complete", rlang::as_label(rlang::enquo(column)))
+  )
+}
+
+###############################################################################
+# check_column_all_true(agent, column, severity)
+# Assert every value in a logical column is TRUE. General-purpose; for spatial
+# data, precompute geometry validity as a column and check it here, e.g.
+#   attrs <- sf_obj |> mutate(geom_valid = sf::st_is_valid(sf_obj)) |>
+#            sf::st_drop_geometry()
+#   new_check_agent(attrs, ...) |> check_column_all_true(geom_valid, "warning")
+# This keeps all checks on a plain data frame and avoids the sf mutate issue.
+###############################################################################
+check_column_all_true <- function(agent, column, severity = "stop") {
+  col_vals_equal(
+    agent,
+    columns = {{ column }},
+    value = TRUE,
+    actions = .check_action_levels(severity),
+    label = sprintf("%s all TRUE", rlang::as_label(rlang::enquo(column)))
+  )
+}
+
+###############################################################################
+# summarize_checks(agent)
+# Run after interrogate(). Returns a list:
+#   report_df  - the per-check results as a plain data.frame
+#   summary    - a short "N passed, M warnings, K errors" string
+#   any_error  - TRUE if any stop-level threshold fired OR a check errored
+#                during evaluation (a broken check is treated as a failure)
+#   any_warn   - TRUE if any warn-level threshold fired
+###############################################################################
+summarize_checks <- function(agent) {
+  rpt <- as.data.frame(get_agent_report(agent, display_table = FALSE))
+
+  n_passed  <- sum(rpt$eval == "OK" & rpt$n_pass == rpt$units, na.rm = TRUE)
+  n_warned  <- sum(rpt$W %in% TRUE)
+  n_stopped <- sum(rpt$S %in% TRUE)
+  n_errored <- sum(rpt$eval == "ERROR", na.rm = TRUE)
+
+  parts <- paste0(n_passed, " passed")
+  if (n_warned  > 0) parts <- c(parts, paste0(n_warned,  " warning", if (n_warned  == 1) "" else "s"))
+  if (n_stopped > 0) parts <- c(parts, paste0(n_stopped, " error",   if (n_stopped == 1) "" else "s"))
+  if (n_errored > 0) parts <- c(parts, paste0(n_errored, " eval-error", if (n_errored == 1) "" else "s"))
+
+  list(
+    report_df = rpt,
+    summary   = paste(parts, collapse = ", "),
+    any_error = any(rpt$S %in% TRUE) || any(rpt$eval == "ERROR", na.rm = TRUE),
+    any_warn  = any(rpt$W %in% TRUE)
+  )
+}
+
+###############################################################################
+# write_check_artifacts(agent, report_df, checks_base, tag, run_ts)
+# Write pointblank's HTML report and a CSV of results to the S3 checks/
+# directory. Returns the S3 URL of the HTML report (for the task manager).
+# Filenames are date-stamped so a history is retained.
+###############################################################################
+write_check_artifacts <- function(agent, report_df, checks_base, tag, run_ts) {
+  date_stamp <- format(run_ts, "%Y%m%d")
+
+  # HTML report (self-contained; no headless browser needed for HTML export)
+  html_local <- tempfile(fileext = ".html")
+  export_report(agent, filename = html_local, quiet = TRUE)
+  html_obj <- file.path(checks_base, sprintf("%s_report_%s.html", tag, date_stamp))
+  put_object(file = html_local, object = html_obj, acl = "public-read")
+
+  # CSV of per-check results. Flatten the list-column before writing.
+  csv_df <- report_df[, c("i", "type", "columns", "values", "eval",
+                          "units", "n_pass", "f_pass", "W", "S", "N")]
+  csv_df$columns <- vapply(csv_df$columns,
+                           function(x) paste(unlist(x), collapse = ";"),
+                           character(1))
+  csv_df$tag <- tag
+  csv_df$check_run <- format(run_ts, "%Y-%m-%dT%H:%M:%S%z")
+  csv_local <- tempfile(fileext = ".csv")
+  write.csv(csv_df, csv_local, row.names = FALSE)
+  csv_obj <- file.path(checks_base, sprintf("%s_checks_%s.csv", tag, date_stamp))
+  put_object(file = csv_local, object = csv_obj, acl = "public-read")
+
+  html_obj
+}


### PR DESCRIPTION
Closes #22 (first implementation; the framework is meant to roll out pipeline-wide after this demo)

## What

Adds `functions/checks.R`, a thin set of wrappers around `pointblank`, and retrofits the cartographic boundaries worker as the test case the team picked.

## The framework (`functions/checks.R`)

- `new_check_agent()` + `check_row_count_range()` / `check_column_complete()` / `check_column_all_true()`: compose checks with a per-check `severity`
- `summarize_checks()`: returns a "# passed, # warnings" string plus an abort flag
- `write_check_artifacts()`: writes pointblank's HTML report and a results CSV to the S3 `checks/` directory

Per-check severity uses pointblank's `action_levels()`: `"stop"` halts the worker, `"warning"` logs and continues. This covers EmmaLi's point that the same check (e.g. row count drop) should be fatal for some datasets and a warning for others.

## Cartographic worker demo

Three checks per layer:
- row count within range -> **error** (wrong count means a broken download)
- all geometries valid -> **warning** (flag it, don't kill the run)
- GEOID complete -> **error** (GEOID is the join key)

Each layer writes an HTML report + results CSV to the `checks/` dir, and the task manager gets three new columns: `last_check_run`, `last_check_status` (a per-layer "# passed, # warnings" summary), `last_check_report_link`.

## Validation

- Local run against real census.gov: all three layers pass (3 checks each), reports generated, and a forced out-of-range value trips an error-level abort
- Docker image builds and the worker runs in-container through the pointblank checks to the expected S3 auth failure

## Two things worth the team's eyes

1. **Build context.** This worker sources the shared `functions/checks.R`, so the image must build from the repo root (documented at the top of the Dockerfile). It's the first worker with a build-time dependency on `functions/`; `dwsrf_worker` (sources `check_env.R`) will need the same. Ties into the pipeline reorg.
2. **Dependency weight.** pointblank pulls ~21 transitive packages and needs the `libuv` system lib (added for the `fs` package its report export uses). Worth confirming the image size is acceptable before rolling pointblank pipeline-wide.

Happy to adjust severities, check choices, or the artifact layout based on the demo.