### PR TITLE
Migrate Alaska, West Virginia and Missouri BWN workers to the new ETL pipeline (#38)

### DIFF
--- a/functions/bwn_helpers.R
+++ b/functions/bwn_helpers.R
@@ -1,0 +1,417 @@
+###############################################################################
+# Shared helpers for the state boil-water-notice (BWN) pipelines (issue #38)
+#
+# Each state fetches from a different source, but the reconcile logic falls into
+# two families driven by how the source publishes advisories:
+#
+#   active feed     - the source lists only advisories currently in effect, so a
+#                     record disappearing implies it was lifted and we date that
+#                     closure to the day we noticed ("Assumed").
+#                     e.g. Alaska, Missouri
+#   rolling window  - the source publishes a moving window (roughly a year) and
+#                     reports real lift dates, so we retain records that age out
+#                     of the window and detect updates to advisories we already
+#                     hold ("Reported").
+#                     e.g. West Virginia
+#
+# Both families are parameterized by their key columns, so a new state is a
+# key_cols vector rather than another copy of the diff. Everything else here
+# (validation, the legacy abort guard, type normalization, the task-manager
+# bridge) is identical across states.
+###############################################################################
+
+# The columns the national BWN summary selects. Every clean_<st>_bwn dataset must
+# lead with these, in this order (see 2_summarize_data.Rmd).
+bwn_contract_cols <- c("pwsid", "date_issued", "date_lifted",
+                       "epic_date_lifted_flag", "date_epic_captured_advisory",
+                       "type", "state", "date_worker_last_ran")
+
+# Columns the reconcile step maintains itself. They are absent from every source
+# feed (the legacy workers appended them in the closed-advisory branch), so a
+# first run has to seed them or the clean step fails on a missing column.
+bwn_managed_cols <- c("date_lifted", "epic_date_lifted_flag")
+
+#' Build a full s3:// URI from a bare object key.
+#' The new pipeline helpers take bare keys, but the legacy task manager stores
+#' full URIs and 2_summarize_data.Rmd feeds clean_link straight to
+#' aws.s3::s3read_using() without a bucket argument, which requires the URI form.
+#' @param key Bare S3 object key
+#' @param bucket Bucket name
+#' @return s3://bucket/key
+bwn_s3_uri <- function(key, bucket = s3_bucket()) {
+  paste0("s3://", bucket, "/", key)
+}
+
+#' Coerce every column of a data frame to character.
+#' The reconcile step compares a freshly-pulled API response against a CSV
+#' baseline, and the two arrive with different types, so both sides are flattened
+#' through this function before being compared or bound. Applying it to BOTH
+#' sides is what makes the join key reliable: run it on one side only and the
+#' halves of the key can disagree.
+#' Numerics are formatted per element rather than with as.character(). BWN join
+#' keys include epoch-millisecond timestamps, and as.character() renders those as
+#' 1.7e+12 at the default options(scipen), so the key would silently never match.
+#' Per-element formatting at digits = 15 also avoids format()'s default 7
+#' significant digits (which would truncate a coordinate like -159.167561616957)
+#' and its habit of padding a whole column to a common width.
+#' @param df Data frame
+#' @return Data frame with every column as character
+as_character_df <- function(df) {
+  to_chr <- function(x) {
+    if (!is.numeric(x)) return(as.character(x))
+    vapply(
+      x,
+      function(v) if (is.na(v)) NA_character_ else
+        format(v, scientific = FALSE, trim = TRUE, digits = 15),
+      character(1)
+    )
+  }
+  df %>% dplyr::mutate(dplyr::across(dplyr::everything(), to_chr))
+}
+
+#' Read a previous BWN raw pull, returning NULL only when it does not exist yet.
+#' The legacy workers read the prior run with an unguarded s3read_using() and
+#' died if the object was missing, which makes a genuinely new pipeline (or a
+#' first run in the dev bucket) impossible.
+#' Only a 404 is treated as "no baseline". Every other failure raises, because a
+#' NULL here also zeroes the row-loss guard in validate_raw_bwn(), so a broad
+#' catch would let a permissions change or a transient outage quietly replace the
+#' accumulated history with a single feed pull.
+#' @param link S3 key of the previous raw dataset
+#' @param bucket Bucket name
+#' @return Data frame, or NULL when the object does not exist
+read_prior_bwn <- function(link, bucket = s3_bucket()) {
+  absent <- tryCatch({
+    s3_client()$head_object(Bucket = bucket, Key = link)
+    FALSE
+  }, error = function(e) {
+    # ONLY a 404 means the object is not there. S3 answers 403 for an object
+    # that exists when the caller lacks s3:ListBucket, and a throttle or outage
+    # gives a 5xx: reading either as "first run" would zero out n_old, disarm
+    # the row-loss guard, and let one feed pull overwrite accumulated history.
+    if (inherits(e, "http_404")) return(TRUE)
+    stop(sprintf("Could not check for a previous run at %s: %s",
+                 link, conditionMessage(e)), call. = FALSE)
+  })
+
+  if (absent) {
+    message(sprintf("No previous run found at %s, treating this as a first run.",
+                    link))
+    return(NULL)
+  }
+  # Any failure from here on is a real error and must not be swallowed either.
+  # coerce_character = FALSE matters: s3_read_csv's own coercion uses
+  # as.character(), which renders an epoch-millisecond value as "1.785024e+12"
+  # at the default scipen. Reading typed and letting as_character_df() format
+  # both sides keeps the two halves of the join key consistent.
+  s3_read_csv(link, bucket = bucket, coerce_character = FALSE)
+}
+
+#' Ensure the columns the reconcile step maintains exist on a fresh pull.
+#' @param df Fresh pull
+#' @return Data frame with bwn_managed_cols present
+.seed_bwn_managed_cols <- function(df) {
+  for (col in bwn_managed_cols) {
+    # rep_len keeps this working on a zero-row frame, where a scalar assignment
+    # would throw "replacement has 1 row, data has 0". An empty pull is a real
+    # scenario: Missouri's feed regularly has only a handful of CWS matches.
+    if (!col %in% names(df)) df[[col]] <- rep_len(NA_character_, nrow(df))
+  }
+  df
+}
+
+#' Reconcile a fresh pull for a state whose source lists only ACTIVE advisories.
+#' Records are partitioned four ways:
+#'   new            - in the fresh pull only
+#'   still active   - in both (the STORED row is kept, so the original detection
+#'                    date survives)
+#'   newly closed   - stored, gone from the feed, no lift date yet -> closed today
+#'   already closed - stored, gone from the feed, already had a lift date
+#' @param fresh Fresh pull, tidied
+#' @param old Previous raw pull, or NULL on a first run
+#' @param key_cols Character vector of columns identifying an advisory
+#' @return Combined data frame
+reconcile_bwn_active_feed <- function(fresh, old, key_cols) {
+  fresh <- as_character_df(fresh)
+  if (is.null(old) || nrow(old) == 0) {
+    # Only a first run needs these seeded: `fresh` becomes the output directly
+    # and the clean step reads both columns. With a baseline present, bind_rows
+    # appends them from the stored side, which also preserves the legacy column
+    # order (source columns first, maintained columns last).
+    message("No baseline to reconcile against, keeping the fresh pull as-is.")
+    return(.seed_bwn_managed_cols(fresh))
+  }
+  # Both sides go through the same formatter. read_prior_bwn() deliberately
+  # reads the baseline typed so this call, not s3_read_csv's scipen-sensitive
+  # as.character(), decides how a numeric key column is rendered.
+  old <- as_character_df(old)
+  .check_bwn_keys(fresh, old, key_cols)
+
+  fresh_key <- .bwn_key(fresh, key_cols)
+  old_key <- .bwn_key(old, key_cols)
+
+  new_rows <- fresh[!(fresh_key %in% old_key), , drop = FALSE]
+  still_active <- old[old_key %in% fresh_key, , drop = FALSE]
+
+  dropped <- old[!(old_key %in% fresh_key), , drop = FALSE]
+  newly_closed <- dropped %>%
+    dplyr::filter(is.na(date_lifted)) %>%
+    dplyr::mutate(date_lifted = as.character(Sys.Date()),
+                  epic_date_lifted_flag = "Assumed")
+  already_closed <- dplyr::filter(dropped, !is.na(date_lifted))
+
+  dplyr::bind_rows(new_rows, still_active, newly_closed, already_closed)
+}
+
+#' Reconcile a fresh pull for a state whose source is a ROLLING WINDOW.
+#' The feed only covers a recent period and reports real lift dates, so two keys
+#' are needed:
+#'   key_cols        identify a specific version of an advisory (including its
+#'                   lift date), so a change to it means the advisory was updated
+#'   update_key_cols identify the advisory itself, independent of its lift date
+#' A fresh row whose update key matches but whose full key does not is the same
+#' advisory with new information (typically a lift date now reported), so it
+#' supersedes the stored row. Stored rows that are not superseded are carried
+#' forward untouched, which is what retains advisories aged out of the window.
+#' @param fresh Fresh pull, tidied
+#' @param old Previous raw pull, or NULL on a first run
+#' @param key_cols Columns identifying a specific version of an advisory
+#' @param update_key_cols Columns identifying the advisory itself
+#' @return Combined data frame
+reconcile_bwn_rolling_window <- function(fresh, old, key_cols, update_key_cols) {
+  # No managed-column seeding here: a rolling-window source reports its own lift
+  # dates (date_lifted is part of key_cols), and the flag is set in the clean
+  # step, so seeding would add a spurious all-NA column to the raw dataset.
+  fresh <- as_character_df(fresh)
+  if (is.null(old) || nrow(old) == 0) {
+    message("No baseline to reconcile against, keeping the fresh pull as-is.")
+    return(fresh)
+  }
+  old <- as_character_df(old)
+  .check_bwn_keys(fresh, old, union(key_cols, update_key_cols))
+
+  # last_epic_run_date records when we first saw an advisory, so it is excluded
+  # from both keys: including it would make every stored row look changed.
+  fresh_cmp <- dplyr::select(fresh, -dplyr::any_of("last_epic_run_date"))
+  old_cmp <- dplyr::select(old, -dplyr::any_of("last_epic_run_date"))
+
+  fresh_full <- .bwn_key(fresh_cmp, key_cols)
+  old_full <- .bwn_key(old_cmp, key_cols)
+  fresh_upd <- .bwn_key(fresh_cmp, update_key_cols)
+  old_upd <- .bwn_key(old_cmp, update_key_cols)
+
+  is_update <- !(fresh_full %in% old_full) & (fresh_upd %in% old_upd)
+  is_new <- !(fresh_full %in% old_full) & !(fresh_upd %in% old_upd)
+
+  updated_rows <- fresh_cmp[is_update, , drop = FALSE] %>%
+    dplyr::mutate(last_epic_run_date = as.character(Sys.Date()))
+  new_rows <- fresh_cmp[is_new, , drop = FALSE] %>%
+    dplyr::mutate(last_epic_run_date = as.character(Sys.Date()))
+
+  # stored rows not being superseded keep their original last_epic_run_date
+  superseded <- .bwn_key(fresh_cmp[is_update, , drop = FALSE], update_key_cols)
+  carried_forward <- old[!(old_upd %in% superseded), , drop = FALSE]
+
+  dplyr::bind_rows(new_rows, updated_rows, carried_forward)
+}
+
+#' Paste the key columns of a data frame into a single identity string.
+#' A separator is required: pasting bare would let neighbouring columns run
+#' together, so ("AK1", "23456") and ("AK12", "3456") would produce the same key
+#' and two distinct advisories would silently collapse into one. The unit
+#' separator cannot occur in this data.
+#' @param df Data frame
+#' @param key_cols Character vector of column names
+#' @return Character vector
+.bwn_key <- function(df, key_cols) {
+  do.call(paste, c(unname(as.list(df[key_cols])), sep = .bwn_key_sep))
+}
+
+# ASCII unit separator, chosen because it cannot appear in the source data
+.bwn_key_sep <- "\u001f"
+
+#' Stop with a clear message if either side is missing a key column.
+#' @param fresh Fresh pull
+#' @param old Stored pull
+#' @param key_cols Required columns
+.check_bwn_keys <- function(fresh, old, key_cols) {
+  missing_fresh <- setdiff(key_cols, names(fresh))
+  missing_old <- setdiff(key_cols, names(old))
+  if (length(missing_fresh) || length(missing_old)) {
+    stop(sprintf(
+      "BWN key columns missing (fresh: %s | stored: %s)",
+      if (length(missing_fresh)) paste(missing_fresh, collapse = ", ") else "none",
+      if (length(missing_old)) paste(missing_old, collapse = ", ") else "none"
+    ), call. = FALSE)
+  }
+  invisible(TRUE)
+}
+
+#' Pointblank validations shared by every raw BWN dataset.
+#' Carries over the legacy abort guard: the workers refused to write when the new
+#' pull had fewer rows than the previous one, or was empty. Here it is a
+#' stop-severity check, so it produces a validation artifact and main_runner
+#' records the failure in the dataset registry.
+#' @param config Main config
+#' @param bwn Reconciled raw BWN data
+#' @param bwn_old Previous raw pull, or NULL on a first run
+#' @param dataset_id e.g. "raw_ak_bwn"
+#' @param label Human-readable agent label
+#' @param pwsid_col Name of the system-id column in the RAW data. Most states use
+#'   "pwsid", but Missouri's source calls it "pws_id" until the clean step
+#'   renames it.
+validate_raw_bwn <- function(config, bwn, bwn_old, dataset_id, label,
+                             pwsid_col = "pwsid") {
+  checks_base <- config$metadata$checks_link
+  run_ts <- Sys.time()
+  n_old <- if (is.null(bwn_old)) 0 else nrow(bwn_old)
+
+  if (!pwsid_col %in% names(bwn)) {
+    stop(sprintf("%s: expected system-id column '%s' not found in the raw data",
+                 dataset_id, pwsid_col), call. = FALSE)
+  }
+
+  checks_df <- bwn %>%
+    dplyr::mutate(
+      system_id_present = !is.na(.data[[pwsid_col]]) & .data[[pwsid_col]] != ""
+    )
+  print(tibble::tibble(rows = nrow(bwn), prior_rows = n_old,
+                       no_row_loss = nrow(bwn) >= n_old))
+
+  # The two scalar guards use specially(): it is handed the whole table and
+  # always reports exactly one validation unit, so an EMPTY dataset still fails
+  # them. Deriving them from the rows (as a col_vals_* check does) would give
+  # zero units on an empty table and pointblank would report "passed" on
+  # precisely the case the legacy guard existed to catch.
+  agent <- new_check_agent(checks_df, label = label) %>%
+    specially(
+      fn = function(t) nrow(t) > 0,
+      actions = action_levels(stop_at = 1),
+      label = "BWN dataset has > 0 rows"
+    ) %>%
+    specially(
+      fn = function(t) nrow(t) >= n_old,
+      actions = action_levels(stop_at = 1),
+      label = sprintf("no row loss vs the previous run (%d rows)", n_old)
+    ) %>%
+    check_column_all_true(system_id_present, severity = "stop") %>%
+    interrogate()
+
+  .report_bwn_checks(agent, checks_base, dataset_id, run_ts)
+}
+
+#' Pointblank validations shared by every clean BWN dataset.
+#' Checks the contract the national BWN summary depends on.
+#' @param config Main config
+#' @param bwn_clean Standardized BWN data
+#' @param dataset_id e.g. "clean_ak_bwn"
+#' @param label Human-readable agent label
+validate_clean_bwn <- function(config, bwn_clean, dataset_id, label) {
+  checks_base <- config$metadata$checks_link
+  run_ts <- Sys.time()
+
+  checks_df <- bwn_clean %>%
+    dplyr::mutate(
+      lifted_flag_valid = epic_date_lifted_flag %in% c("Assumed", "Reported")
+    )
+
+  agent <- new_check_agent(checks_df, label = label) %>%
+    check_column_complete(pwsid, severity = "stop") %>%
+    check_column_complete(date_issued, severity = "warning") %>%
+    check_column_all_true(lifted_flag_valid, severity = "stop") %>%
+    interrogate()
+
+  .report_bwn_checks(agent, checks_base, dataset_id, run_ts)
+}
+
+#' Summarize an interrogated agent, push its artifacts to S3, and abort on error.
+#' Not BWN-specific: this is the summarize/report/abort block every pipeline in
+#' pipelines/ repeats. Worth promoting into functions/checks.R eventually so the
+#' other pipelines can drop their copies.
+#' @param agent Interrogated pointblank agent
+#' @param checks_base S3 prefix for check artifacts
+#' @param dataset_id Dataset id, used as the artifact tag
+#' @param run_ts Run timestamp
+.report_bwn_checks <- function(agent, checks_base, dataset_id, run_ts) {
+  result <- summarize_checks(agent)
+  message(sprintf("Validation result summary: %s", result$summary))
+
+  report_link <- write_check_artifacts(
+    agent = agent, report_df = result$report_df,
+    checks_base = checks_base, tag = dataset_id, run_ts = run_ts
+  )
+  message(sprintf("Validation reports pushed to S3: %s", report_link))
+
+  if (isTRUE(result$any_error)) {
+    stop(sprintf("VALIDATION FAILED: %s", result$summary), call. = FALSE)
+  }
+  message(sprintf("%s validation checks passed successfully.", dataset_id))
+  invisible(TRUE)
+}
+
+#' Apply the shared tail of a clean BWN dataset.
+#' The caller supplies the state-specific mapping (which source column becomes
+#' date_issued / date_lifted, the type value, the state name, and the
+#' epic_date_lifted_flag); this puts the contract columns in the required order
+#' and stamps the run date.
+#' @param df Data frame already carrying date_issued, date_lifted,
+#'   epic_date_lifted_flag, type, state and last_epic_run_date
+#' @return Data frame with the contract columns leading
+finalize_bwn_clean <- function(df) {
+  df %>%
+    dplyr::rename(date_epic_captured_advisory = last_epic_run_date) %>%
+    dplyr::mutate(date_worker_last_ran = Sys.Date()) %>%
+    dplyr::relocate(dplyr::all_of(bwn_contract_cols))
+}
+
+#' TODO(#38): temporary bridge to the legacy task manager.
+#' 2_summarize_data.Rmd builds national_bwn_summary by matching legacy dataset
+#' names (e.g. "ak_bwn") in task_manager_data_summary.csv and reading clean_link,
+#' so a migrated pipeline has to keep that row current or the state silently
+#' drops out of the national dataset. Links are written as full s3:// URIs
+#' because that consumer passes clean_link to aws.s3::s3read_using() without a
+#' bucket argument. Remove this once all_bwn replaces that logic.
+#' @param task_manager_link S3 key of task_manager_data_summary.csv
+#' @param dataset_i Legacy dataset name, e.g. "ak_bwn"
+#' @param raw_link S3 key of the raw dataset
+#' @param clean_link S3 key of the clean dataset
+update_bwn_task_manager <- function(task_manager_link, dataset_i, raw_link,
+                                    clean_link) {
+  if (is.null(task_manager_link)) {
+    message("No task_manager_link configured, skipping the legacy bridge.")
+    return(invisible(FALSE))
+  }
+
+  message(sprintf(
+    "TODO(#38) legacy bridge: updating the task manager row for %s. This exists only until all_bwn replaces the 2_summarize_data.Rmd roll-up.",
+    dataset_i))
+  task_manager <- s3_read_csv(task_manager_link)
+
+  new_row <- data.frame(dataset = dataset_i,
+                        date_downloaded = as.character(Sys.Date()),
+                        raw_link = bwn_s3_uri(raw_link),
+                        clean_link = bwn_s3_uri(clean_link),
+                        stringsAsFactors = FALSE)
+
+  if (!(dataset_i %in% task_manager$dataset)) {
+    task_manager <- dplyr::bind_rows(task_manager,
+                                     data.frame(dataset = dataset_i))
+  }
+
+  # preserve every column this pipeline does not own
+  dont_touch <- setdiff(names(task_manager), names(new_row))
+  updated_row <- task_manager %>%
+    dplyr::filter(dataset == dataset_i) %>%
+    dplyr::select(dataset, dplyr::all_of(dont_touch)) %>%
+    dplyr::left_join(new_row, by = "dataset") %>%
+    dplyr::mutate(dplyr::across(dplyr::everything(), as.character))
+
+  updated_task_manager <- task_manager %>%
+    dplyr::filter(dataset != dataset_i) %>%
+    dplyr::bind_rows(updated_row) %>%
+    dplyr::arrange(dataset)
+
+  s3_write_csv(updated_task_manager, task_manager_link, acl = "public-read")
+  message("Legacy task manager updated.")
+  invisible(TRUE)
+}

--- a/functions/bwn_helpers.R
+++ b/functions/bwn_helpers.R
@@ -16,8 +16,8 @@
 #
 # Both families are parameterized by their key columns, so a new state is a
 # key_cols vector rather than another copy of the diff. Everything else here
-# (validation, the legacy abort guard, type normalization, the task-manager
-# bridge) is identical across states.
+# (validation, the legacy abort guard, type normalization) is identical across
+# states.
 ###############################################################################
 
 # The columns the national BWN summary selects. Every clean_<st>_bwn dataset must
@@ -30,17 +30,6 @@ bwn_contract_cols <- c("pwsid", "date_issued", "date_lifted",
 # feed (the legacy workers appended them in the closed-advisory branch), so a
 # first run has to seed them or the clean step fails on a missing column.
 bwn_managed_cols <- c("date_lifted", "epic_date_lifted_flag")
-
-#' Build a full s3:// URI from a bare object key.
-#' The new pipeline helpers take bare keys, but the legacy task manager stores
-#' full URIs and 2_summarize_data.Rmd feeds clean_link straight to
-#' aws.s3::s3read_using() without a bucket argument, which requires the URI form.
-#' @param key Bare S3 object key
-#' @param bucket Bucket name
-#' @return s3://bucket/key
-bwn_s3_uri <- function(key, bucket = s3_bucket()) {
-  paste0("s3://", bucket, "/", key)
-}
 
 #' Coerce every column of a data frame to character.
 #' The reconcile step compares a freshly-pulled API response against a CSV
@@ -362,56 +351,4 @@ finalize_bwn_clean <- function(df) {
     dplyr::rename(date_epic_captured_advisory = last_epic_run_date) %>%
     dplyr::mutate(date_worker_last_ran = Sys.Date()) %>%
     dplyr::relocate(dplyr::all_of(bwn_contract_cols))
-}
-
-#' TODO(#38): temporary bridge to the legacy task manager.
-#' 2_summarize_data.Rmd builds national_bwn_summary by matching legacy dataset
-#' names (e.g. "ak_bwn") in task_manager_data_summary.csv and reading clean_link,
-#' so a migrated pipeline has to keep that row current or the state silently
-#' drops out of the national dataset. Links are written as full s3:// URIs
-#' because that consumer passes clean_link to aws.s3::s3read_using() without a
-#' bucket argument. Remove this once all_bwn replaces that logic.
-#' @param task_manager_link S3 key of task_manager_data_summary.csv
-#' @param dataset_i Legacy dataset name, e.g. "ak_bwn"
-#' @param raw_link S3 key of the raw dataset
-#' @param clean_link S3 key of the clean dataset
-update_bwn_task_manager <- function(task_manager_link, dataset_i, raw_link,
-                                    clean_link) {
-  if (is.null(task_manager_link)) {
-    message("No task_manager_link configured, skipping the legacy bridge.")
-    return(invisible(FALSE))
-  }
-
-  message(sprintf(
-    "TODO(#38) legacy bridge: updating the task manager row for %s. This exists only until all_bwn replaces the 2_summarize_data.Rmd roll-up.",
-    dataset_i))
-  task_manager <- s3_read_csv(task_manager_link)
-
-  new_row <- data.frame(dataset = dataset_i,
-                        date_downloaded = as.character(Sys.Date()),
-                        raw_link = bwn_s3_uri(raw_link),
-                        clean_link = bwn_s3_uri(clean_link),
-                        stringsAsFactors = FALSE)
-
-  if (!(dataset_i %in% task_manager$dataset)) {
-    task_manager <- dplyr::bind_rows(task_manager,
-                                     data.frame(dataset = dataset_i))
-  }
-
-  # preserve every column this pipeline does not own
-  dont_touch <- setdiff(names(task_manager), names(new_row))
-  updated_row <- task_manager %>%
-    dplyr::filter(dataset == dataset_i) %>%
-    dplyr::select(dataset, dplyr::all_of(dont_touch)) %>%
-    dplyr::left_join(new_row, by = "dataset") %>%
-    dplyr::mutate(dplyr::across(dplyr::everything(), as.character))
-
-  updated_task_manager <- task_manager %>%
-    dplyr::filter(dataset != dataset_i) %>%
-    dplyr::bind_rows(updated_row) %>%
-    dplyr::arrange(dataset)
-
-  s3_write_csv(updated_task_manager, task_manager_link, acl = "public-read")
-  message("Legacy task manager updated.")
-  invisible(TRUE)
 }

--- a/main_config.json
+++ b/main_config.json
@@ -371,8 +371,7 @@
     "link": "national-dw-tool/raw/ak/water-system/ak_bwn.csv",
     "staged_link": "N/A",
     "input_links": {
-      "pwsid_names_link": "national-dw-tool/raw/national/water-system/sabs_pwsid_names.csv",
-      "task_manager_link": "national-dw-tool/task_manager_data_summary.csv"
+      "pwsid_names_link": "national-dw-tool/raw/national/water-system/sabs_pwsid_names.csv"
     },
     "source": "Alaska DEC",
     "source_url": "https://dec.alaska.gov/arcgis/rest/services/EH/BWN_DND/FeatureServer/0",
@@ -408,8 +407,7 @@
     "link": "national-dw-tool/raw/wv/water-system/wv_bwn.csv",
     "staged_link": "N/A",
     "input_links": {
-      "pwsid_names_link": "national-dw-tool/raw/national/water-system/sabs_pwsid_names.csv",
-      "task_manager_link": "national-dw-tool/task_manager_data_summary.csv"
+      "pwsid_names_link": "national-dw-tool/raw/national/water-system/sabs_pwsid_names.csv"
     },
     "source": "West Virginia DHHR",
     "source_url": "https://oehsportal.wvdhhr.org/boilwater/home/boilwaternotices",
@@ -445,8 +443,7 @@
     "link": "national-dw-tool/raw/mo/water-system/mo_bwn.csv",
     "staged_link": "N/A",
     "input_links": {
-      "pwsid_names_link": "national-dw-tool/raw/national/water-system/sabs_pwsid_names.csv",
-      "task_manager_link": "national-dw-tool/task_manager_data_summary.csv"
+      "pwsid_names_link": "national-dw-tool/raw/national/water-system/sabs_pwsid_names.csv"
     },
     "source": "Missouri DNR",
     "source_url": "https://data.mo.gov/resource/j2a5-itxh.json",

--- a/main_config.json
+++ b/main_config.json
@@ -324,6 +324,117 @@
     "quality_check_link": "N/A",
     "quality_score": "N/A"
   },
+  "raw_ak_bwn": {
+    "triggers": [
+      "clean_ak_bwn"
+    ],
+    "clean_name": "Alaska Boil Water Notices",
+    "update_freq": "daily (automatic)",
+    "category": "water-system",
+    "link": "national-dw-tool/raw/ak/water-system/ak_bwn.csv",
+    "staged_link": "N/A",
+    "input_links": {
+      "pwsid_names_link": "national-dw-tool/raw/national/water-system/sabs_pwsid_names.csv",
+      "task_manager_link": "national-dw-tool/task_manager_data_summary.csv"
+    },
+    "source": "Alaska DEC",
+    "source_url": "https://dec.alaska.gov/arcgis/rest/services/EH/BWN_DND/FeatureServer/0",
+    "spatial_level": "State",
+    "date_range": "N/A",
+    "quality_check_link": "N/A",
+    "quality_score": "N/A"
+  },
+  "clean_ak_bwn": {
+    "triggers": [],
+    "clean_name": "Alaska Boil Water Notices (Standardized)",
+    "update_freq": "daily (automatic)",
+    "category": "water-system",
+    "link": "national-dw-tool/clean/ak/ak_bwn.csv",
+    "staged_link": "N/A",
+    "input_links": {
+      "raw_link": "national-dw-tool/raw/ak/water-system/ak_bwn.csv"
+    },
+    "source": "N/A",
+    "source_url": "N/A",
+    "spatial_level": "State",
+    "date_range": "N/A",
+    "quality_check_link": "N/A",
+    "quality_score": "N/A"
+  },
+  "raw_wv_bwn": {
+    "triggers": [
+      "clean_wv_bwn"
+    ],
+    "clean_name": "West Virginia Boil Water Notices",
+    "update_freq": "quarterly (automatic)",
+    "category": "water-system",
+    "link": "national-dw-tool/raw/wv/water-system/wv_bwn.csv",
+    "staged_link": "N/A",
+    "input_links": {
+      "pwsid_names_link": "national-dw-tool/raw/national/water-system/sabs_pwsid_names.csv",
+      "task_manager_link": "national-dw-tool/task_manager_data_summary.csv"
+    },
+    "source": "West Virginia DHHR",
+    "source_url": "https://oehsportal.wvdhhr.org/boilwater/home/boilwaternotices",
+    "spatial_level": "State",
+    "date_range": "N/A",
+    "quality_check_link": "N/A",
+    "quality_score": "N/A"
+  },
+  "clean_wv_bwn": {
+    "triggers": [],
+    "clean_name": "West Virginia Boil Water Notices (Standardized)",
+    "update_freq": "quarterly (automatic)",
+    "category": "water-system",
+    "link": "national-dw-tool/clean/wv/wv_bwn.csv",
+    "staged_link": "N/A",
+    "input_links": {
+      "raw_link": "national-dw-tool/raw/wv/water-system/wv_bwn.csv"
+    },
+    "source": "N/A",
+    "source_url": "N/A",
+    "spatial_level": "State",
+    "date_range": "N/A",
+    "quality_check_link": "N/A",
+    "quality_score": "N/A"
+  },
+  "raw_mo_bwn": {
+    "triggers": [
+      "clean_mo_bwn"
+    ],
+    "clean_name": "Missouri Boil Water Notices",
+    "update_freq": "daily (automatic)",
+    "category": "water-system",
+    "link": "national-dw-tool/raw/mo/water-system/mo_bwn.csv",
+    "staged_link": "N/A",
+    "input_links": {
+      "pwsid_names_link": "national-dw-tool/raw/national/water-system/sabs_pwsid_names.csv",
+      "task_manager_link": "national-dw-tool/task_manager_data_summary.csv"
+    },
+    "source": "Missouri DNR",
+    "source_url": "https://data.mo.gov/resource/j2a5-itxh.json",
+    "spatial_level": "State",
+    "date_range": "N/A",
+    "quality_check_link": "N/A",
+    "quality_score": "N/A"
+  },
+  "clean_mo_bwn": {
+    "triggers": [],
+    "clean_name": "Missouri Boil Water Notices (Standardized)",
+    "update_freq": "daily (automatic)",
+    "category": "water-system",
+    "link": "national-dw-tool/clean/mo/mo_bwn.csv",
+    "staged_link": "N/A",
+    "input_links": {
+      "raw_link": "national-dw-tool/raw/mo/water-system/mo_bwn.csv"
+    },
+    "source": "N/A",
+    "source_url": "N/A",
+    "spatial_level": "State",
+    "date_range": "N/A",
+    "quality_check_link": "N/A",
+    "quality_score": "N/A"
+  },
   "example_dataset_id": {
     "triggers": [],
     "clean_name": "N/A",

--- a/main_runner.R
+++ b/main_runner.R
@@ -10,6 +10,7 @@ source("functions/registry_updates.R")
 source("functions/checks.R")
 source("functions/s3_client.R")
 source("functions/pipeline_helpers.R")
+source("functions/bwn_helpers.R")
 source("functions/xwalk_census_geo_sabs.R")
 
 options(scipen = 999)
@@ -121,7 +122,10 @@ pipeline_router <- list(
   "clean_sabs_cejst" = run_clean_sabs_cejst_pipeline,
   "raw_ejscreen" = run_ejscreen_pipeline,
   "clean_sabs_ejscreen" = run_clean_sabs_ejscreen_pipeline,
-  "staged_pwsid_npdes_usts_rmps_imp" = run_staged_pwsid_npdes_usts_rmps_imp_pipeline
+  "staged_pwsid_npdes_usts_rmps_imp" = run_staged_pwsid_npdes_usts_rmps_imp_pipeline,
+  "raw_ak_bwn" = run_ak_bwn_pipeline,
+  "raw_wv_bwn" = run_wv_bwn_pipeline,
+  "raw_mo_bwn" = run_mo_bwn_pipeline
   # "dwsrf" = run_dwsrf_pipeline,
   # "all_bwn" = run_bwn_merge_pipeline
 )

--- a/pipelines/pipeline_ak_bwn.R
+++ b/pipelines/pipeline_ak_bwn.R
@@ -20,14 +20,6 @@ run_ak_bwn_pipeline <- function(config, dataset_id) {
   message("Running AK BWN clean pipeline...")
   run_clean_ak_bwn_pipeline(config, "clean_ak_bwn", bwn_raw = ak_bwn_raw)
 
-  # Bridge last, once both datasets exist, matching the legacy worker order. If
-  # the clean step aborts, the task manager keeps pointing at the last good run
-  # rather than advertising a dataset that was never written.
-  update_bwn_task_manager(
-    config[[dataset_id]]$input_links$task_manager_link,
-    "ak_bwn", config[[dataset_id]]$link, config$clean_ak_bwn$link
-  )
-
   message(sprintf("%s pipeline completed successfully.", dataset_id))
 }
 

--- a/pipelines/pipeline_ak_bwn.R
+++ b/pipelines/pipeline_ak_bwn.R
@@ -1,0 +1,130 @@
+###############################################################################
+# Alaska Boil Water Notices (issue #38)
+# Migrated from 1_downloaders/daily/ak_worker/ak_daily.R
+#
+# Alaska's DEC publishes only *currently active* advisories, so this pipeline has
+# to infer closures: a record that disappears from the feed is treated as lifted
+# on the day we noticed, flagged epic_date_lifted_flag = "Assumed". States that
+# publish a real lift date use "Reported" instead. That flag is how the national
+# summary distinguishes the two, so it is preserved deliberately here.
+#
+# Shared BWN helpers live in functions/bwn_helpers.R.
+###############################################################################
+
+#' Pull Alaska BWN data, then run the AK BWN clean pipeline
+#' @param config Main config
+#' @param dataset_id "raw_ak_bwn"
+run_ak_bwn_pipeline <- function(config, dataset_id) {
+  ak_bwn_raw <- update_raw_ak_bwn(config, dataset_id)
+
+  message("Running AK BWN clean pipeline...")
+  run_clean_ak_bwn_pipeline(config, "clean_ak_bwn", bwn_raw = ak_bwn_raw)
+
+  # Bridge last, once both datasets exist, matching the legacy worker order. If
+  # the clean step aborts, the task manager keeps pointing at the last good run
+  # rather than advertising a dataset that was never written.
+  update_bwn_task_manager(
+    config[[dataset_id]]$input_links$task_manager_link,
+    "ak_bwn", config[[dataset_id]]$link, config$clean_ak_bwn$link
+  )
+
+  message(sprintf("%s pipeline completed successfully.", dataset_id))
+}
+
+#' Fetch, reconcile against the previous run, validate, and save raw AK BWN data
+#' @param config Main config
+#' @param dataset_id "raw_ak_bwn"
+#' @return Reconciled raw BWN data frame
+update_raw_ak_bwn <- function(config, dataset_id) {
+  message(sprintf("Grabbing config variables for dataset %s...", dataset_id))
+  sub_config <- config[[dataset_id]]
+  source_url <- sub_config$source_url
+  link <- sub_config$link
+  pwsid_names_link <- sub_config$input_links$pwsid_names_link
+
+  message("Pulling Alaska BWN layer from DEC ArcGIS...")
+  ak_bwn <- arcpullr::get_spatial_layer(source_url)
+
+  message("Filtering to community water systems...")
+  epa_sabs_pwsids <- s3_read_csv(pwsid_names_link)
+
+  ak_bwn_tidy <- ak_bwn %>%
+    as.data.frame() %>%
+    janitor::clean_names() %>%
+    mutate(pwsid = str_squish(pwsid)) %>%
+    filter(pwsid %in% epa_sabs_pwsids$pwsid) %>%
+    mutate(
+      # the feed reports the issue date as epoch milliseconds
+      bwn_issue_date_clean = as.character(as.POSIXct(bwn_issue_date / 1000,
+                                                     origin = "1970-01-01",
+                                                     tz = "America/Anchorage")),
+      geoms = as.character(geoms),
+      last_epic_run_date = as.character(Sys.Date())
+    )
+
+  message("Reading the previous run for reconciliation...")
+  ak_bwn_old <- read_prior_bwn(link)
+
+  ak_bwn_reconciled <- reconcile_ak_bwn(ak_bwn_tidy, ak_bwn_old)
+
+  message("Validating raw_ak_bwn...")
+  validate_raw_bwn(config, ak_bwn_reconciled, ak_bwn_old, dataset_id,
+                   label = "AK Boil Water Notice Validation")
+
+  message(sprintf("Writing raw_ak_bwn to S3 to %s...", link))
+  s3_write_csv(ak_bwn_reconciled, link)
+
+  return(ak_bwn_reconciled)
+}
+
+#' Reconcile a fresh Alaska pull against the previous run.
+#' Records are keyed on pwsid + issue date. New records are added, records that
+#' have dropped off the feed without a lift date are closed as of today, and
+#' records still present keep their original detection date.
+#' @param ak_bwn_tidy Fresh pull, tidied
+#' @param ak_bwn_old Previous raw pull, or NULL on a first run
+#' @return Combined data frame
+reconcile_ak_bwn <- function(ak_bwn_tidy, ak_bwn_old) {
+  reconcile_bwn_active_feed(ak_bwn_tidy, ak_bwn_old,
+                            key_cols = c("pwsid", "bwn_issue_date"))
+}
+
+#' Standardize AK BWN into the shared cross-state BWN schema
+#' @param config Main config
+#' @param dataset_id "clean_ak_bwn"
+#' @param bwn_raw Optional pre-loaded raw BWN data. If NULL, downloaded from S3.
+run_clean_ak_bwn_pipeline <- function(config, dataset_id = "clean_ak_bwn",
+                                      bwn_raw = NULL) {
+  message(sprintf("Grabbing config variables for dataset %s...", dataset_id))
+  sub_config <- config[[dataset_id]]
+  raw_link <- sub_config$input_links$raw_link
+  link <- sub_config$link
+
+  if (is.null(bwn_raw)) {
+    message("Downloading raw AK BWN from S3...")
+    bwn_raw <- s3_read_csv(raw_link)
+  }
+
+  message("Standardizing to the shared BWN schema...")
+  ak_bwn_clean <- bwn_raw %>%
+    mutate(date_issued = as.Date(bwn_issue_date_clean, tryFormats = c("%Y-%m-%d")),
+           date_lifted = as.Date(date_lifted, tryFormats = c("%Y-%m-%d")),
+           last_epic_run_date = as.Date(last_epic_run_date,
+                                        tryFormats = c("%Y-%m-%d")),
+           # Alaska publishes only active advisories, so every closure we record
+           # is inferred rather than reported. See the header note.
+           epic_date_lifted_flag = "Assumed",
+           type = name,
+           state = "Alaska") %>%
+    finalize_bwn_clean()
+
+  message("Validating clean_ak_bwn...")
+  validate_clean_bwn(config, ak_bwn_clean, dataset_id,
+                     label = "AK BWN Clean Validation")
+
+  message(sprintf("Writing clean_ak_bwn to S3 to %s...", link))
+  s3_write_csv(ak_bwn_clean, link)
+
+  message(sprintf("%s pipeline completed successfully.", dataset_id))
+  return(ak_bwn_clean)
+}

--- a/pipelines/pipeline_mo_bwn.R
+++ b/pipelines/pipeline_mo_bwn.R
@@ -21,14 +21,6 @@ run_mo_bwn_pipeline <- function(config, dataset_id) {
   message("Running MO BWN clean pipeline...")
   run_clean_mo_bwn_pipeline(config, "clean_mo_bwn", bwn_raw = mo_bwn_raw)
 
-  # Bridge last, once both datasets exist, matching the legacy worker order. If
-  # the clean step aborts, the task manager keeps pointing at the last good run
-  # rather than advertising a dataset that was never written.
-  update_bwn_task_manager(
-    config[[dataset_id]]$input_links$task_manager_link,
-    "mo_bwn", config[[dataset_id]]$link, config$clean_mo_bwn$link
-  )
-
   message(sprintf("%s pipeline completed successfully.", dataset_id))
 }
 

--- a/pipelines/pipeline_mo_bwn.R
+++ b/pipelines/pipeline_mo_bwn.R
@@ -1,0 +1,145 @@
+###############################################################################
+# Missouri Boil Water Notices (issue #38)
+# Migrated from 1_downloaders/daily/mo_worker/mo_daily.R
+#
+# Missouri publishes boil orders through a Socrata dataset (DNR WPP Boil Order
+# Report). Like Alaska, the feed lists only advisories currently in effect, so a
+# record disappearing implies it was lifted and we date that closure to the day
+# we noticed it ("Assumed"). Unlike Alaska, Missouri's stored history can already
+# contain "Reported" flags from records supplied directly by the state, so the
+# clean step only fills the flag in where it is missing rather than overwriting.
+#
+# Shared BWN helpers live in functions/bwn_helpers.R.
+###############################################################################
+
+#' Pull Missouri BWN data, then run the MO BWN clean pipeline
+#' @param config Main config
+#' @param dataset_id "raw_mo_bwn"
+run_mo_bwn_pipeline <- function(config, dataset_id) {
+  mo_bwn_raw <- update_raw_mo_bwn(config, dataset_id)
+
+  message("Running MO BWN clean pipeline...")
+  run_clean_mo_bwn_pipeline(config, "clean_mo_bwn", bwn_raw = mo_bwn_raw)
+
+  # Bridge last, once both datasets exist, matching the legacy worker order. If
+  # the clean step aborts, the task manager keeps pointing at the last good run
+  # rather than advertising a dataset that was never written.
+  update_bwn_task_manager(
+    config[[dataset_id]]$input_links$task_manager_link,
+    "mo_bwn", config[[dataset_id]]$link, config$clean_mo_bwn$link
+  )
+
+  message(sprintf("%s pipeline completed successfully.", dataset_id))
+}
+
+#' Fetch, reconcile against the previous run, validate, and save raw MO BWN data
+#' @param config Main config
+#' @param dataset_id "raw_mo_bwn"
+#' @return Reconciled raw BWN data frame
+update_raw_mo_bwn <- function(config, dataset_id) {
+  message(sprintf("Grabbing config variables for dataset %s...", dataset_id))
+  sub_config <- config[[dataset_id]]
+  source_url <- sub_config$source_url
+  link <- sub_config$link
+  pwsid_names_link <- sub_config$input_links$pwsid_names_link
+
+  message("Pulling Missouri boil order data from the Socrata endpoint...")
+  response <- httr::GET(source_url)
+  if (httr::http_error(response)) {
+    stop(sprintf("MO BWN request failed with HTTP %s", httr::status_code(response)),
+         call. = FALSE)
+  }
+  mo_bwn <- jsonlite::fromJSON(httr::content(response, "text",
+                                             encoding = "UTF-8")) %>%
+    as.data.frame() %>%
+    janitor::clean_names() %>%
+    select(issue_date:geocoded_column) %>%
+    mutate(issue_date = as.Date(issue_date, tryFormats = c("%Y-%m-%d")))
+
+  message("Filtering to community water systems...")
+  epa_sabs_pwsids <- s3_read_csv(pwsid_names_link)
+
+  mo_bwn_tidy <- mo_bwn %>%
+    # Socrata returns the location as a nested data frame, so flatten it out and
+    # drop the nested column (it cannot be written to CSV as-is).
+    mutate(geocode_lat = geocoded_column$latitude,
+           geocode_long = geocoded_column$longitude) %>%
+    select(-geocoded_column) %>%
+    # Missouri's feed carries a large share of non-community systems
+    filter(pws_id %in% epa_sabs_pwsids$pwsid) %>%
+    mutate(last_epic_run_date = as.character(Sys.Date()))
+
+  message("Reading the previous run for reconciliation...")
+  mo_bwn_old <- read_prior_bwn(link)
+
+  mo_bwn_reconciled <- reconcile_mo_bwn(mo_bwn_tidy, mo_bwn_old)
+
+  message("Validating raw_mo_bwn...")
+  validate_raw_bwn(config, mo_bwn_reconciled, mo_bwn_old, dataset_id,
+                   label = "MO Boil Water Notice Validation",
+                   pwsid_col = "pws_id")
+
+  message(sprintf("Writing raw_mo_bwn to S3 to %s...", link))
+  s3_write_csv(mo_bwn_reconciled, link)
+
+  return(mo_bwn_reconciled)
+}
+
+#' Reconcile a fresh Missouri pull against the previous run.
+#' Missouri's feed lists only active boil orders, so this uses the shared
+#' active-feed reconcile. An advisory is identified by its issue date, system id
+#' and contaminant, since one system can have concurrent orders for different
+#' contaminants.
+#' @param mo_bwn_tidy Fresh pull, tidied
+#' @param mo_bwn_old Previous raw pull, or NULL on a first run
+#' @return Combined data frame
+reconcile_mo_bwn <- function(mo_bwn_tidy, mo_bwn_old) {
+  reconcile_bwn_active_feed(
+    mo_bwn_tidy, mo_bwn_old,
+    key_cols = c("issue_date", "pws_id", "contaminant_of_concern")
+  )
+}
+
+#' Standardize MO BWN into the shared cross-state BWN schema
+#' @param config Main config
+#' @param dataset_id "clean_mo_bwn"
+#' @param bwn_raw Optional pre-loaded raw BWN data. If NULL, downloaded from S3.
+run_clean_mo_bwn_pipeline <- function(config, dataset_id = "clean_mo_bwn",
+                                      bwn_raw = NULL) {
+  message(sprintf("Grabbing config variables for dataset %s...", dataset_id))
+  sub_config <- config[[dataset_id]]
+  raw_link <- sub_config$input_links$raw_link
+  link <- sub_config$link
+
+  if (is.null(bwn_raw)) {
+    message("Downloading raw MO BWN from S3...")
+    bwn_raw <- s3_read_csv(raw_link)
+  }
+
+  message("Standardizing to the shared BWN schema...")
+  mo_bwn_clean <- bwn_raw %>%
+    rename(date_issued = issue_date,
+           pwsid = pws_id) %>%
+    mutate(
+      # Records supplied directly by the state can already carry a "Reported"
+      # flag, so only fill in the ones we inferred ourselves.
+      epic_date_lifted_flag = coalesce(epic_date_lifted_flag, "Assumed"),
+      date_issued = as.Date(date_issued, tryFormats = c("%Y-%m-%d")),
+      date_lifted = as.Date(date_lifted, tryFormats = c("%Y-%m-%d")),
+      last_epic_run_date = as.Date(last_epic_run_date,
+                                   tryFormats = c("%Y-%m-%d")),
+      type = "Assumed - Boil Order",
+      state = "Missouri"
+    ) %>%
+    finalize_bwn_clean()
+
+  message("Validating clean_mo_bwn...")
+  validate_clean_bwn(config, mo_bwn_clean, dataset_id,
+                     label = "MO BWN Clean Validation")
+
+  message(sprintf("Writing clean_mo_bwn to S3 to %s...", link))
+  s3_write_csv(mo_bwn_clean, link)
+
+  message(sprintf("%s pipeline completed successfully.", dataset_id))
+  return(mo_bwn_clean)
+}

--- a/pipelines/pipeline_wv_bwn.R
+++ b/pipelines/pipeline_wv_bwn.R
@@ -24,14 +24,6 @@ run_wv_bwn_pipeline <- function(config, dataset_id) {
   message("Running WV BWN clean pipeline...")
   run_clean_wv_bwn_pipeline(config, "clean_wv_bwn", bwn_raw = wv_bwn_raw)
 
-  # Bridge last, once both datasets exist, matching the legacy worker order. If
-  # the clean step aborts, the task manager keeps pointing at the last good run
-  # rather than advertising a dataset that was never written.
-  update_bwn_task_manager(
-    config[[dataset_id]]$input_links$task_manager_link,
-    "wv_bwn", config[[dataset_id]]$link, config$clean_wv_bwn$link
-  )
-
   message(sprintf("%s pipeline completed successfully.", dataset_id))
 }
 

--- a/pipelines/pipeline_wv_bwn.R
+++ b/pipelines/pipeline_wv_bwn.R
@@ -1,0 +1,143 @@
+###############################################################################
+# West Virginia Boil Water Notices (issue #38)
+# Migrated from 1_downloaders/quarterly/wv_worker/wv_quarterly.R
+#
+# West Virginia's portal exposes a JSON endpoint (found by inspecting the page)
+# that returns a rolling window of roughly the past year. Two consequences drive
+# the reconcile logic:
+#   1. Advisories that age out of the window must be retained from our own
+#      records, or history would silently disappear.
+#   2. An advisory already in our records can come back with a lift date filled
+#      in, so we need to detect an *update* to an existing row, not just new rows.
+# That is why this state keys on two ids rather than one. Unlike Alaska, WV
+# publishes real lift dates, so epic_date_lifted_flag is "Reported".
+#
+# Shared BWN helpers live in functions/bwn_helpers.R.
+###############################################################################
+
+#' Pull West Virginia BWN data, then run the WV BWN clean pipeline
+#' @param config Main config
+#' @param dataset_id "raw_wv_bwn"
+run_wv_bwn_pipeline <- function(config, dataset_id) {
+  wv_bwn_raw <- update_raw_wv_bwn(config, dataset_id)
+
+  message("Running WV BWN clean pipeline...")
+  run_clean_wv_bwn_pipeline(config, "clean_wv_bwn", bwn_raw = wv_bwn_raw)
+
+  # Bridge last, once both datasets exist, matching the legacy worker order. If
+  # the clean step aborts, the task manager keeps pointing at the last good run
+  # rather than advertising a dataset that was never written.
+  update_bwn_task_manager(
+    config[[dataset_id]]$input_links$task_manager_link,
+    "wv_bwn", config[[dataset_id]]$link, config$clean_wv_bwn$link
+  )
+
+  message(sprintf("%s pipeline completed successfully.", dataset_id))
+}
+
+#' Fetch, reconcile against the previous run, validate, and save raw WV BWN data
+#' @param config Main config
+#' @param dataset_id "raw_wv_bwn"
+#' @return Reconciled raw BWN data frame
+update_raw_wv_bwn <- function(config, dataset_id) {
+  message(sprintf("Grabbing config variables for dataset %s...", dataset_id))
+  sub_config <- config[[dataset_id]]
+  source_url <- sub_config$source_url
+  link <- sub_config$link
+  pwsid_names_link <- sub_config$input_links$pwsid_names_link
+
+  message("Pulling West Virginia BWN data from the WVDHHR endpoint...")
+  response <- httr::GET(source_url)
+  if (httr::http_error(response)) {
+    stop(sprintf("WV BWN request failed with HTTP %s", httr::status_code(response)),
+         call. = FALSE)
+  }
+  wv_bwn <- jsonlite::fromJSON(httr::content(response, "text",
+                                             encoding = "UTF-8"))
+
+  message("Filtering to community water systems...")
+  epa_sabs_pwsids <- s3_read_csv(pwsid_names_link)
+
+  wv_bwn_tidy <- wv_bwn %>%
+    janitor::clean_names() %>%
+    filter(pwsid %in% epa_sabs_pwsids$pwsid) %>%
+    mutate(last_epic_run_date = as.character(Sys.Date()))
+
+  message("Reading the previous run for reconciliation...")
+  wv_bwn_old <- read_prior_bwn(link)
+
+  wv_bwn_reconciled <- reconcile_wv_bwn(wv_bwn_tidy, wv_bwn_old)
+
+  message("Validating raw_wv_bwn...")
+  validate_raw_bwn(config, wv_bwn_reconciled, wv_bwn_old, dataset_id,
+                   label = "WV Boil Water Notice Validation")
+
+  message(sprintf("Writing raw_wv_bwn to S3 to %s...", link))
+  s3_write_csv(wv_bwn_reconciled, link)
+
+  return(wv_bwn_reconciled)
+}
+
+#' Reconcile a fresh West Virginia pull against the previous run.
+#' Keys on two ids because the source is a rolling window:
+#'   full_id   = pwsid + date_issued + date_lifted + details  (fully identical row)
+#'   update_id = pwsid + date_issued + details                (same advisory)
+#' A row whose update_id matches but whose full_id does not is the *same*
+#' advisory with changed details (typically a lift date now reported), so the
+#' fresh version replaces the stored one. Rows matching neither are new. Stored
+#' rows that are not being updated are carried forward untouched, which is what
+#' retains advisories that have aged out of the window.
+#' @param wv_bwn_tidy Fresh pull, tidied
+#' @param wv_bwn_old Previous raw pull, or NULL on a first run
+#' @return Combined data frame
+reconcile_wv_bwn <- function(wv_bwn_tidy, wv_bwn_old) {
+  reconcile_bwn_rolling_window(
+    wv_bwn_tidy, wv_bwn_old,
+    key_cols        = c("pwsid", "date_issued", "date_lifted", "details"),
+    update_key_cols = c("pwsid", "date_issued", "details")
+  )
+}
+
+#' Standardize WV BWN into the shared cross-state BWN schema
+#' @param config Main config
+#' @param dataset_id "clean_wv_bwn"
+#' @param bwn_raw Optional pre-loaded raw BWN data. If NULL, downloaded from S3.
+run_clean_wv_bwn_pipeline <- function(config, dataset_id = "clean_wv_bwn",
+                                      bwn_raw = NULL) {
+  message(sprintf("Grabbing config variables for dataset %s...", dataset_id))
+  sub_config <- config[[dataset_id]]
+  raw_link <- sub_config$input_links$raw_link
+  link <- sub_config$link
+
+  if (is.null(bwn_raw)) {
+    message("Downloading raw WV BWN from S3...")
+    bwn_raw <- s3_read_csv(raw_link)
+  }
+
+  message("Standardizing to the shared BWN schema...")
+  wv_bwn_clean <- bwn_raw %>%
+    # keep the source values under state-suffixed names, then derive the
+    # standardized date columns from them
+    rename(date_issued_wv = date_issued,
+           date_lifted_wv = date_lifted) %>%
+    select(-any_of("id")) %>%
+    mutate(date_issued = as.Date(date_issued_wv, tryFormats = c("%Y-%m-%d")),
+           date_lifted = as.Date(date_lifted_wv, tryFormats = c("%Y-%m-%d")),
+           last_epic_run_date = as.Date(last_epic_run_date,
+                                        tryFormats = c("%Y-%m-%d")),
+           type = "Assumed - Boil Water Notices",
+           # WV reports real lift dates, unlike Alaska's inferred closures
+           epic_date_lifted_flag = "Reported",
+           state = "West Virginia") %>%
+    finalize_bwn_clean()
+
+  message("Validating clean_wv_bwn...")
+  validate_clean_bwn(config, wv_bwn_clean, dataset_id,
+                     label = "WV BWN Clean Validation")
+
+  message(sprintf("Writing clean_wv_bwn to S3 to %s...", link))
+  s3_write_csv(wv_bwn_clean, link)
+
+  message(sprintf("%s pipeline completed successfully.", dataset_id))
+  return(wv_bwn_clean)
+}


### PR DESCRIPTION
First slice of the BWN migration, cc @EmmaLiTsai. These three pull from structured JSON APIs (AK from an ArcGIS FeatureServer, WV from the WVDHHR endpoint, MO from Socrata), so they exercise the new format without also fighting HTML scraping. The rvest states (ME, OR, NM, WA, AR, FL) would follow.

**Files**
- `pipelines/pipeline_{ak,wv,mo}_bwn.R` - one per state
- `functions/bwn_helpers.R` - shared BWN layer, sourced from `main_runner.R`
- `main_config.json` - `raw_` and `clean_` entries per state
- `main_runner.R` - one `source()` line, three router entries

**Structure**

I ended up with two shared reconcile functions rather than one per state. AK and MO both treat a disappearance from the feed as a lift (flagged `"Assumed"`), while WV retains records that age out of its window and detects updates to advisories already held (flagged `"Reported"`). Both take their key columns as arguments, so the remaining states should slot into one or the other rather than needing another copy of the diff. Each `reconcile_<st>_bwn()` is a thin wrapper holding that state's keys and rationale. Happy to restructure if you'd rather they stayed separate per state.

**Temporary task-manager bridge**

`2_summarize_data.Rmd` still discovers BWN datasets by regex-matching legacy names in `task_manager_data_summary.csv` and reading `clean_link`, so each pipeline keeps that row current. Without it a migrated state would silently drop out of `national_bwn_summary`. Marked `TODO(#38)` and removable once `all_bwn` lands.

**Deliberate behavior changes from the legacy workers**

- **A missing baseline is now a first run, not a crash.** The legacy read of the prior run was unguarded. Only a genuinely absent object is treated this way; transient S3 errors still raise, since swallowing them would let a single feed pull replace accumulated history.
- **The abort guard is now a pointblank stop-check** rather than an inline `quit()`, so it produces a validation artifact and the runner records the failure in the dataset registry. Worth flagging: the legacy wrote `WORKER FAILED - SEE LOGS` into the task manager, which the Rmd filters on. The new failure surface is the registry, which that Rmd cannot see, so a broken feed now serves last-good data rather than dropping the state. Happy to restore the sentinel if you would rather keep that signal.
- **Types are normalized before the diff.** The fresh API pull is typed while `s3_read_csv()` returns the stored baseline as character, so `bind_rows()` failed. Numerics are formatted explicitly rather than relying on `options(scipen)` being set, since the join keys include epoch-millisecond timestamps.
- HTTP status is checked on the WV and MO requests, so an error page cannot reach `fromJSON`.

**How to run**
```bash
Rscript main_runner.R --dev=TRUE --update-registries=TRUE --run-pipeline raw_ak_bwn
```

**Verification**

All three run clean in dev against live sources. Output compared against the existing prod clean files: AK 352/352 rows, WV 7770/7648, MO 23/23, identical column order and zero differences on the eight contract columns, zero advisories lost. WV's row growth is the update path working, 17 previously-open advisories now carry reported lift dates. Prod was untouched throughout, verified by ETag before and after.

**Two things I would like your read on**

1. I have left the legacy `1_downloaders/.../{ak,mo,wv}_worker/` directories in place, assuming they come out once scheduling points at the new pipelines. Happy to remove them here or in a follow-up, whichever fits your cutover.
2. `functions/bwn_helpers.R` has a small private helper that summarizes an agent, writes the artifacts and aborts. It is not BWN-specific, it is the same block repeated in the merged pipelines. Happy to promote it into `functions/checks.R` as a follow-up so the others can drop their copies, but I left shared code alone here.

I used an LLM as a research aid while working through the legacy logic. The migration decisions, the verification against real data, and the review of the output are my own.

Part of #38.
