### PR TITLE
Pipeline reorg additions

### DIFF
--- a/functions/census_xwalk_helpers.R
+++ b/functions/census_xwalk_helpers.R
@@ -1,0 +1,96 @@
+################################################################################
+# Census Crosswalk Helpers
+################################################################################
+
+################################################################################
+# .grab_census_blocks
+# EmmaLi Tsai
+# Jan 2026
+################################################################################
+# This function pulls the 2020 or 2010 census blocks for a particular state.
+#
+# inputs:
+#   - sf_data_i: sf file of data with census geographies (for example, CEJST)
+#   - state_i: state abbreviation
+#   - fips_col: character of the fips column name in sf_data_i
+#   - blocks_2020 : whether the function should pull 2020 or 2010 census blocks
+#
+# output: returns the correct census blocks as an sf oject
+#
+################################################################################
+
+# grab the appropriate census blocks:
+.grab_census_blocks <- function(sf_data_i, fips_col,
+                                state_i, blocks_2020 = TRUE){
+
+  if(blocks_2020 == TRUE){
+    message("Using 2020 Blocks as Weights")
+
+    # grabbing 2020 from tigris (which has all of the columns we need):
+    state_blocks <- tigris::blocks(
+      state = state_i,
+      year = 2020) %>%
+      st_transform(., crs = 5070) %>%
+      # standardize column names:
+      rename(pop_weight = "POP20",
+             housing_weight = "HOUSING20")
+  } else {
+    message("Using 2010 Blocks as Weights")
+
+    # NOTES: Getting 2010 block geometries with populations and housing info 
+    # to use as weights for pw_interpolation was hard. Using the blocks() 
+    # function from tigris didn't return blocks or populations, and the 
+    # get_decennial function from tidycensus requires you to loop through 
+    # every county in the state (see here: https://github.com/walkerke/tidycensus/issues/598)
+    # I also couldn't download the data directly 
+    # from the census website in R (the census website blocked all of this 
+    # traffic): https://www2.census.gov/geo/tiger/TIGER2010BLKPOPHU/
+    
+    # this is the new URL that the dev version of tigris is using to get around 
+    # the fact the census website blocked all FTP traffic - using this 
+    # to download block populations and houses for a whole state  
+    state_blocks_2010_key <- paste0("national-dw-tool/census_blocks_2010/", state_i, "_blocks_2010.geojson")
+
+    # pull blocks from where they're stored on AWS
+    state_blocks <- s3_read_geojson(state_blocks_2010_key) %>%
+      st_transform(., crs = 5070)
+  }
+  return(state_blocks)
+}
+
+# find significant state overlaps:
+.find_state_overlaps <- function(sab_t){
+  ##############################################################################
+  # Finding sab and state overlaps
+  ##############################################################################
+
+  # finding OG overlap to determine whether the overlap is simply a boundary
+  # error:
+  og_sab_area <- sab_t %>%
+    mutate(og_area = as.numeric(st_area(.))) %>%
+    as.data.frame() %>%
+    select(pwsid, og_area)
+
+  # grabbing state boundaries
+  state_boundaries <- tigris::states() %>%
+    janitor::clean_names() %>%
+    st_transform(., crs = st_crs(sab_t))
+
+  # finding where sabs are located - this is needed for some SABs that don't
+  # match to a census state code (i.e., Navajo Nation)
+  message("Finding what state to pull data from")
+  sab_state <- st_intersection(sab_t, state_boundaries)
+
+  # make helper dataframe of states, pwsids, and % overlap
+  states_pwsids <- sab_state %>%
+    mutate(area_overlap = as.numeric(st_area(.))) %>%
+    as.data.frame() %>%
+    select(pwsid, stusps, statefp, area_overlap) %>%
+    left_join(og_sab_area) %>%
+    unique() %>%
+    mutate(pct_overlap = 100*(area_overlap/og_area))
+    # filtering for only meaningful area overlaps:
+    # filter(pct_overlap >= 20)
+
+  return(states_pwsids)
+}

--- a/functions/pipeline_helpers.R
+++ b/functions/pipeline_helpers.R
@@ -4,3 +4,21 @@
 #' @param huc12 Character or numeric vector of HUC12 codes
 #' @return Character vector of HUC12 codes, left-padded with zeros to 12 digits
 fix_huc12 <- function(huc12) stringr::str_pad(huc12, width = 12, side = "left", pad = "0")
+
+# Caches the census variable interpolation methods sheet per session.
+# get_census_var_interp_methods() is called twice per pipeline run so we only
+# need one Google Sheets fetch instead of two.
+.census_interp_env <- new.env(parent = emptyenv())
+
+#' Grabs the census variable interpolation methods sheet.
+#' @param config Main config
+get_census_var_interp_methods <- function(config) {
+  if (is.null(.census_interp_env$data)) {
+    googlesheets4::gs4_deauth()
+    .census_interp_env$data <- googlesheets4::read_sheet(
+      config$metadata$census_var_methods_sheet_url, sheet = "census_geo_methods"
+    ) %>%
+      janitor::clean_names()
+  }
+  .census_interp_env$data
+}

--- a/functions/xwalk_census_geo_sabs.R
+++ b/functions/xwalk_census_geo_sabs.R
@@ -105,8 +105,8 @@ xwalk_census_geo_sabs <- function(sabs, sf_data_census, interp_methods,
   # they'll rbind the wrong things :) 
   rm(list = ls(pattern = 'a_ext|a_int|pw_ext_hh|pw_int_hh|pw_ext_pop|pw_int_pop|xwalk_data_loop'))
   
-  # pull in helper functions used in the crosswalk: 
-  source("./functions/helper_functions.R")
+  # pull in helper functions used in the crosswalk:
+  source("./functions/census_xwalk_helpers.R")
   
   # turn off spherical geoms, which should be fine since we're not really 
   # working towards the poles & data are on a projected CRS 
@@ -194,12 +194,15 @@ xwalk_census_geo_sabs <- function(sabs, sf_data_census, interp_methods,
   
   for(i in 1:length(unique_states_sab_both)){
     state_i <- unique_states_sab_both[i]
-    message("Working on: ", state_i, ", loop ", i, " out of ", 
+    message("Working on: ", state_i, ", loop ", i, " out of ",
             length(unique_states_sab_both))
-    
-    # filtering sabs and census data - noting that crosswalk_states may have 
-    # multiple entries 
-    sab_i <- sab_t %>% 
+
+    # Guard against stale data from a previous state iteration
+    rm(list = ls(pattern = 'a_ext|a_int|pw_ext_hh|pw_int_hh|pw_ext_pop|pw_int_pop'))
+
+    # filtering sabs and census data - noting that crosswalk_states may have
+    # multiple entries
+    sab_i <- sab_t %>%
       filter(grepl(state_i, overlap_states)) %>%
       select(pwsid)
     sf_data_i <- sf_data_census_tidy_codes %>% 
@@ -239,7 +242,7 @@ xwalk_census_geo_sabs <- function(sabs, sf_data_census, interp_methods,
           select(!!sym(fips_col), pw_interp_intensive_pop$vars)
         
         # interpolatin' - starting with intensive population vars: 
-        pw_int_pop <- interpolate_pw(
+        pw_int_pop <- tidycensus::interpolate_pw(
           from = pw_interp_intensive_pop_data,
           to = sab_i,
           to_id = "pwsid",
@@ -266,7 +269,7 @@ xwalk_census_geo_sabs <- function(sabs, sf_data_census, interp_methods,
           select(!!sym(fips_col), pw_interp_intensive_hh$vars)
         
         # interpolatin' 
-        pw_int_hh <- interpolate_pw(
+        pw_int_hh <- tidycensus::interpolate_pw(
           from = pw_interp_intensive_hh_data,
           to = sab_i,
           to_id = "pwsid",
@@ -293,7 +296,7 @@ xwalk_census_geo_sabs <- function(sabs, sf_data_census, interp_methods,
           select(!!sym(fips_col), pw_interp_extensive_pop$vars)
         
         # interpolatin' 
-        pw_ext_pop <- interpolate_pw(
+        pw_ext_pop <- tidycensus::interpolate_pw(
           from = pw_interp_extensive_pop_data,
           to = sab_i,
           to_id = "pwsid",
@@ -320,7 +323,7 @@ xwalk_census_geo_sabs <- function(sabs, sf_data_census, interp_methods,
           select(!!sym(fips_col), pw_interp_extensive_hh$vars)
         
         # interpolatin' 
-        pw_ext_hh <- interpolate_pw(
+        pw_ext_hh <- tidycensus::interpolate_pw(
           from = pw_interp_extensive_hh_data,
           to = sab_i,
           to_id = "pwsid",
@@ -419,23 +422,21 @@ xwalk_census_geo_sabs <- function(sabs, sf_data_census, interp_methods,
     }
     
     message("Recombining Data")
-    
-    # grab relevant datasets from global environment and add them to a data frame
+
+    # Testing on CEJST reorg was crashing because tidycensus::interpolate_pw()
+    # and areal::aw_interpolate() were returning different row counts for the same
+    # state. Joining by pwsid avoids this by marking NA for a method's variables
+    # if pwsid is missing so the whole crosswalk doesn't crash.
     data_bind <- mget(ls(pattern = "a_ext|a_int|pw_ext_hh|pw_int_hh|pw_ext_pop|pw_int_pop")) %>%
-      as.data.frame() %>%
-      # keep only one pwsid column (can confirm they all line up and were 
-      # arranged by pwsid earlier in the code)
-      rename(pwsid = colnames(.)[1]) %>%
-      # removing duplicated column names
-      select(-contains("interp_method")) %>%
-      select(-contains(".pwsid")) %>%
-      # recombining with OG sab geometries 
+      lapply(function(df) df %>% select(-interp_method)) %>%
+      Reduce(function(x, y) full_join(x, y, by = "pwsid"), .) %>%
+      # recombining with OG sab geometries
       left_join(sab_i) %>%
       st_as_sf() %>%
-      # adding final columns to keep track of the state that was crosswalked: 
+      # adding final columns to keep track of the state that was crosswalked:
       mutate(crosswalk_state = state_i) %>%
       relocate(crosswalk_state, .after = pwsid)
-    
+
     # binding for each iteration of the loop: 
     xwalk_data_loop <- bind_rows(xwalk_data_loop, data_bind)
     

--- a/main_config.json
+++ b/main_config.json
@@ -2,10 +2,30 @@
   "metadata": {
     "dataset_registry_link": "national-dw-tool/dataset_registry.csv",
     "variable_registry_link": "national-dw-tool/variable_registry.csv",
-    "checks_link": "national-dw-tool/validation"
+    "checks_link": "national-dw-tool/validation",
+    "census_var_methods_sheet_url": "https://docs.google.com/spreadsheets/d/15iVYq2v3Gpy5Zug3BhYC0vU4L-axV5g0drZt4-uLv-Q/edit?gid=1622581968#gid=1622581968"
+  },
+  "example_dataset_id": {
+    "triggers": [],
+    "clean_name": "N/A",
+    "update_freq": "N/A",
+    "category": "N/A",
+    "link": "N/A",
+    "staged_link": "N/A",
+    "input_links": {},
+    "source": "N/A",
+    "source_url": "N/A",
+    "spatial_level": "N/A",
+    "date_range": "N/A",
+    "quality_check_link": "N/A",
+    "quality_score": "N/A"
   },
   "raw_huc12": {
-    "triggers": ["clean_huc12_open_usts", "clean_huc12_rmp_sites", "clean_huc12_npdes"],
+    "triggers": [
+      "clean_huc12_open_usts",
+      "clean_huc12_rmp_sites",
+      "clean_huc12_npdes"
+    ],
     "clean_name": "HUC12 Geometries",
     "update_freq": "yearly (manual)",
     "category": "environmental",
@@ -19,9 +39,11 @@
     "date_range": "N/A",
     "quality_check_link": "N/A",
     "quality_score": "N/A"
-  },  
+  },
   "raw_open_usts": {
-    "triggers": ["clean_huc12_open_usts"],
+    "triggers": [
+      "clean_huc12_open_usts"
+    ],
     "clean_name": "Open Underground Storage Tanks",
     "update_freq": "static (manual)",
     "category": "environmental",
@@ -54,7 +76,9 @@
     "quality_score": "N/A"
   },
   "raw_imp_waters": {
-    "triggers": ["clean_huc12_imp_waters"],
+    "triggers": [
+      "clean_huc12_imp_waters"
+    ],
     "clean_name": "303(d) Impaired Waters List",
     "update_freq": "quarterly (automatic)",
     "category": "environmental",
@@ -86,7 +110,9 @@
     "quality_score": "N/A"
   },
   "raw_rmp_sites": {
-    "triggers": ["clean_huc12_rmp_sites"],
+    "triggers": [
+      "clean_huc12_rmp_sites"
+    ],
     "clean_name": "RMP Sites",
     "update_freq": "quarterly (manual)",
     "category": "environmental",
@@ -119,7 +145,9 @@
     "quality_score": "N/A"
   },
   "raw_npdes_permits": {
-    "triggers": ["clean_huc12_npdes"],
+    "triggers": [
+      "clean_huc12_npdes"
+    ],
     "clean_name": "NPDES Facilities",
     "update_freq": "quarterly (automatic)",
     "category": "environmental",
@@ -191,7 +219,9 @@
     "quality_score": "N/A"
   },
   "raw_epa_sabs": {
-    "triggers": ["clean_epa_sabs"],
+    "triggers": [
+      "clean_epa_sabs"
+    ],
     "clean_name": "EPA Service Area Boundaries",
     "update_freq": "yearly (manual)",
     "category": "water-system",
@@ -224,7 +254,9 @@
     "quality_score": "N/A"
   },
   "raw_svi": {
-    "triggers": ["clean_sabs_svi"],
+    "triggers": [
+      "clean_sabs_svi"
+    ],
     "clean_name": "CDC/ATSDR Social Vulnerability Index",
     "update_freq": "yearly (manual)",
     "category": "socioeconomic",
@@ -232,7 +264,7 @@
     "staged_link": "N/A",
     "input_links": {},
     "source": "CDC/ATSDR",
-    "source_url": "N/A",
+    "source_url": "(downloaded locally) https://www.atsdr.cdc.gov/place-health/php/svi/svi-data-documentation-download.html",
     "local_source_path": "./data/SVI2022_US_tract.gdb",
     "spatial_level": "Census Tract",
     "date_range": "N/A",
@@ -258,7 +290,9 @@
     "quality_score": "N/A"
   },
   "raw_cejst": {
-    "triggers": ["clean_sabs_cejst"],
+    "triggers": [
+      "clean_sabs_cejst"
+    ],
     "clean_name": "Climate and Economic Justice Screening Tool",
     "update_freq": "yearly (manual)",
     "category": "socioeconomic",
@@ -267,6 +301,7 @@
     "input_links": {},
     "source": "Council on Environmental Quality",
     "source_url": "https://dblew8dgr6ajz.cloudfront.net/data-versions/2.0/data/score/downloadable/2.0-shapefile-codebook.zip",
+    "communities_csv_url": "https://dblew8dgr6ajz.cloudfront.net/data-versions/2.0/data/score/downloadable/2.0-communities.csv",
     "spatial_level": "Census Tract (2010)",
     "date_range": "N/A",
     "quality_check_link": "N/A",
@@ -291,7 +326,9 @@
     "quality_score": "N/A"
   },
   "raw_ejscreen": {
-    "triggers": ["clean_sabs_ejscreen"],
+    "triggers": [
+      "clean_sabs_ejscreen"
+    ],
     "clean_name": "EPA EJScreen",
     "update_freq": "yearly (manual)",
     "category": "socioeconomic",
@@ -299,7 +336,7 @@
     "staged_link": "N/A",
     "input_links": {},
     "source": "EPA",
-    "source_url": "N/A",
+    "source_url": "(downloaded locally) https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/RLR5AX",
     "local_source_path": "./data/EJSCREEN_2024_BG_with_AS_CNMI_GU_VI.csv",
     "spatial_level": "Block Group",
     "date_range": "N/A",
@@ -324,17 +361,113 @@
     "quality_check_link": "N/A",
     "quality_score": "N/A"
   },
-  "example_dataset_id": {
-    "triggers": [],
-    "clean_name": "N/A",
-    "update_freq": "N/A",
-    "category": "N/A",
-    "link": "N/A",
+  "raw_ak_bwn": {
+    "triggers": [
+      "clean_ak_bwn"
+    ],
+    "clean_name": "Alaska Boil Water Notices",
+    "update_freq": "daily (automatic)",
+    "category": "water-system",
+    "link": "national-dw-tool/raw/ak/water-system/ak_bwn.csv",
     "staged_link": "N/A",
-    "input_links": {},
+    "input_links": {
+      "pwsid_names_link": "national-dw-tool/raw/national/water-system/sabs_pwsid_names.csv",
+      "task_manager_link": "national-dw-tool/task_manager_data_summary.csv"
+    },
+    "source": "Alaska DEC",
+    "source_url": "https://dec.alaska.gov/arcgis/rest/services/EH/BWN_DND/FeatureServer/0",
+    "spatial_level": "State",
+    "date_range": "N/A",
+    "quality_check_link": "N/A",
+    "quality_score": "N/A"
+  },
+  "clean_ak_bwn": {
+    "triggers": [],
+    "clean_name": "Alaska Boil Water Notices (Standardized)",
+    "update_freq": "daily (automatic)",
+    "category": "water-system",
+    "link": "national-dw-tool/clean/ak/ak_bwn.csv",
+    "staged_link": "N/A",
+    "input_links": {
+      "raw_link": "national-dw-tool/raw/ak/water-system/ak_bwn.csv"
+    },
     "source": "N/A",
     "source_url": "N/A",
-    "spatial_level": "N/A",
+    "spatial_level": "State",
+    "date_range": "N/A",
+    "quality_check_link": "N/A",
+    "quality_score": "N/A"
+  },
+  "raw_wv_bwn": {
+    "triggers": [
+      "clean_wv_bwn"
+    ],
+    "clean_name": "West Virginia Boil Water Notices",
+    "update_freq": "quarterly (automatic)",
+    "category": "water-system",
+    "link": "national-dw-tool/raw/wv/water-system/wv_bwn.csv",
+    "staged_link": "N/A",
+    "input_links": {
+      "pwsid_names_link": "national-dw-tool/raw/national/water-system/sabs_pwsid_names.csv",
+      "task_manager_link": "national-dw-tool/task_manager_data_summary.csv"
+    },
+    "source": "West Virginia DHHR",
+    "source_url": "https://oehsportal.wvdhhr.org/boilwater/home/boilwaternotices",
+    "spatial_level": "State",
+    "date_range": "N/A",
+    "quality_check_link": "N/A",
+    "quality_score": "N/A"
+  },
+  "clean_wv_bwn": {
+    "triggers": [],
+    "clean_name": "West Virginia Boil Water Notices (Standardized)",
+    "update_freq": "quarterly (automatic)",
+    "category": "water-system",
+    "link": "national-dw-tool/clean/wv/wv_bwn.csv",
+    "staged_link": "N/A",
+    "input_links": {
+      "raw_link": "national-dw-tool/raw/wv/water-system/wv_bwn.csv"
+    },
+    "source": "N/A",
+    "source_url": "N/A",
+    "spatial_level": "State",
+    "date_range": "N/A",
+    "quality_check_link": "N/A",
+    "quality_score": "N/A"
+  },
+  "raw_mo_bwn": {
+    "triggers": [
+      "clean_mo_bwn"
+    ],
+    "clean_name": "Missouri Boil Water Notices",
+    "update_freq": "daily (automatic)",
+    "category": "water-system",
+    "link": "national-dw-tool/raw/mo/water-system/mo_bwn.csv",
+    "staged_link": "N/A",
+    "input_links": {
+      "pwsid_names_link": "national-dw-tool/raw/national/water-system/sabs_pwsid_names.csv",
+      "task_manager_link": "national-dw-tool/task_manager_data_summary.csv"
+    },
+    "source": "Missouri DNR",
+    "source_url": "https://data.mo.gov/resource/j2a5-itxh.json",
+    "spatial_level": "State",
+    "date_range": "N/A",
+    "quality_check_link": "N/A",
+    "quality_score": "N/A"
+  },
+  "clean_mo_bwn": {
+    "triggers": [],
+    "clean_name": "Missouri Boil Water Notices (Standardized)",
+    "update_freq": "daily (automatic)",
+    "category": "water-system",
+    "link": "national-dw-tool/clean/mo/mo_bwn.csv",
+    "staged_link": "N/A",
+    "input_links": {
+      "raw_link": "national-dw-tool/raw/mo/water-system/mo_bwn.csv"
+    },
+    "source": "N/A",
+    "source_url": "N/A",
+    "spatial_level": "State",
     "date_range": "N/A",
     "quality_check_link": "N/A",
     "quality_score": "N/A"

--- a/pipelines/pipeline_cejst.R
+++ b/pipelines/pipeline_cejst.R
@@ -1,0 +1,127 @@
+################################################################################
+# Both CEJST sources below are pulled. Data is split across two URLs.
+#
+# 1. Shapefile + codebook zip (a zip within a zip), from source_url:
+#    https://dblew8dgr6ajz.cloudfront.net/data-versions/2.0/data/score/downloadable/2.0-shapefile-codebook.zip
+#    Provides the 2010 census tract geometries (geoid10) - no scored variables.
+#
+# 2. Communities CSV, from communities_csv_url:
+#    https://dblew8dgr6ajz.cloudfront.net/data-versions/2.0/data/score/downloadable/2.0-communities.csv
+#    Provides the actual scored variables (joined to the shapefile by geoid10).
+################################################################################
+
+#' Pull CEJST (Climate and Economic Justice Screening Tool) and crosswalk onto EPA SABs
+#' @param config Main config
+#' @param dataset_id "raw_cejst"
+run_cejst_pipeline <- function(config, dataset_id) {
+  update_raw_cejst(config, dataset_id)
+
+  message("Running SABs and CEJST crosswalk pipeline...")
+  run_clean_sabs_cejst_pipeline(config, "clean_sabs_cejst")
+
+  message(sprintf("%s pipeline completed successfully.", dataset_id))
+}
+
+#' Download CEJST shapefile + communities CSV, then join, clean, and validate
+update_raw_cejst <- function(config, dataset_id) {
+  message(sprintf("Grabbing config variables for dataset %s...", dataset_id))
+  sub_config <- config[[dataset_id]]
+  link <- sub_config$link
+  communities_csv_url <- sub_config$communities_csv_url
+
+  # NOTE - CEJST uses 2010 census tract boundaries. This is a zip within a zip.
+  message("Downloading CEJST shapefile+codebook archive...")
+  file_loc <- tempfile(pattern = "cejst_working_")
+  on.exit(unlink(file_loc, recursive = TRUE), add = TRUE)
+  outer_zip <- paste0(file_loc, ".zip")
+  on.exit(unlink(outer_zip), add = TRUE)
+  download.file(sub_config$source_url, destfile = outer_zip, mode = "wb", quiet = FALSE)
+  unzip(zipfile = outer_zip, exdir = file_loc)
+
+  message("Unzipping nested shapefile archive...")
+  inner_zip <- paste0(file_loc, "/usa.zip")
+  unzip(zipfile = inner_zip, exdir = file_loc)
+
+  # we just want the geoid10 and geometries, to match with the communities csv
+  cejst_geoms <- st_read(paste0(file_loc, "/usa.shp"), quiet = TRUE) %>%
+    janitor::clean_names() %>%
+    select(geoid10)
+
+  cejst_vars <- get_census_var_interp_methods(config) %>%
+    filter(dataset == "cejst") %>%
+    select(var)
+
+  message("Downloading CEJST communities CSV...")
+  # in addition to the shapefile (which has geometries), we need columns
+  # that aren't in the shapefile
+  cejst_tidy <- read.csv(communities_csv_url) %>%
+    janitor::clean_names() %>%
+    select(census_tract_2010_id, all_of(cejst_vars$var)) %>%
+    rename(geoid10 = census_tract_2010_id) %>%
+    mutate(geoid10 = as.character(geoid10),
+           geoid10 = case_when(nchar(geoid10) == 10 ~ paste0("0", geoid10), TRUE ~ geoid10)) %>%
+    left_join(cejst_geoms, by = "geoid10") %>%
+    st_as_sf() %>%
+    mutate(last_epic_run_date = Sys.Date(),
+           identified_as_disadvantaged = case_when(
+             identified_as_disadvantaged == "True" ~ 1,
+             identified_as_disadvantaged == "False" ~ 0
+           )) %>%
+    # from 1/29/2026 run, there are ~367 tracts with empty geometries
+    filter(!st_is_empty(.))
+
+  message("Validating raw CEJST...")
+  validate_raw_cejst(config, cejst_tidy, dataset_id)
+
+  message("Saving CEJST dataset to S3...")
+  s3_write_geojson(cejst_tidy, link)
+}
+
+#' Pointblank validations for raw CEJST
+validate_raw_cejst <- function(config, cejst_tidy, dataset_id) {
+  checks_base <- config$metadata$checks_link
+  run_ts <- Sys.time()
+
+  message(sprintf("row_count: %d", nrow(cejst_tidy)))
+  attrs <- sf::st_drop_geometry(cejst_tidy)
+
+  agent <- new_check_agent(attrs, label = "CEJST Validation") %>%
+    check_row_count_range(min_rows = 70000, max_rows = 80000, severity = "stop") %>%
+    interrogate()
+
+  result <- summarize_checks(agent)
+  message(sprintf("Validation result summary: %s", result$summary))
+
+  report_link <- write_check_artifacts(
+    agent       = agent,
+    report_df   = result$report_df,
+    checks_base = checks_base,
+    tag         = dataset_id,
+    run_ts      = run_ts
+  )
+  message(sprintf("Validation reports pushed to S3: %s", report_link))
+
+  if (isTRUE(result$any_error)) {
+    stop(sprintf("VALIDATION FAILED: %s", result$summary), call. = FALSE)
+  }
+
+  message("CEJST validation checks passed successfully.")
+  return(TRUE)
+}
+
+#' Crosswalk CEJST onto EPA SABs
+#' @param dataset_id "clean_sabs_cejst"
+run_clean_sabs_cejst_pipeline <- function(config, dataset_id = "clean_sabs_cejst") {
+  message(sprintf("Grabbing config variables for dataset %s...", dataset_id))
+  sub_config <- config[[dataset_id]]
+  raw_link <- sub_config$input_links$raw_link
+
+  message("Downloading raw CEJST from S3...")
+  cejst <- s3_read_geojson(raw_link) %>%
+    mutate(geoid10 = case_when(nchar(geoid10) == 10 ~ paste0("0", geoid10), TRUE ~ geoid10))
+
+  # NOTE - CEJST uses 2010 census tract geometries
+  run_sabs_xwalk_pipeline(config, dataset_id, xwalk_dataset_name="cejst",
+                           sf_data_census=cejst, fips_col = "geoid10",
+                           blocks_2020 = FALSE)
+}

--- a/pipelines/pipeline_ejscreen.R
+++ b/pipelines/pipeline_ejscreen.R
@@ -1,0 +1,125 @@
+################################################################################
+# EJScreen has no public download API, so it must be downloaded by hand
+# before this pipeline can run.
+#
+# Steps:
+# 1. Go to the Harvard Dataverse dataset page:
+#    https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/RLR5AX
+# 2. Download the file named "EJSCREEN_2024_BG_with_AS_CNMI_GU_VI.csv".
+# 3. Place it at ./data/EJSCREEN_2024_BG_with_AS_CNMI_GU_VI.csv (relative to
+#    the repo root), matching raw_ejscreen.local_source_path in main_config.json.
+################################################################################
+
+#' Pull EPA EJScreen and crosswalk onto EPA SABs
+#' @param config Main config
+#' @param dataset_id "raw_ejscreen"
+run_ejscreen_pipeline <- function(config, dataset_id) {
+  update_raw_ejscreen(config, dataset_id)
+
+  message("Running SABs and EJScreen crosswalk pipeline...")
+  run_clean_sabs_ejscreen_pipeline(config, "clean_sabs_ejscreen")
+
+  message(sprintf("%s pipeline completed successfully.", dataset_id))
+}
+
+#' Read, clean, and validate locally downloaded EJScreen CSV
+update_raw_ejscreen <- function(config, dataset_id) {
+  message(sprintf("Grabbing config variables for dataset %s...", dataset_id))
+  sub_config <- config[[dataset_id]]
+  local_path <- sub_config$local_source_path
+  link <- sub_config$link
+
+  if (!file.exists(local_path)) {
+    stop(sprintf(
+      "EJScreen source file not found at %s. Follow download steps in pipeline_ejscreen.R.",
+      local_path
+    ), call. = FALSE)
+  }
+
+  message("Reading local EJScreen CSV...")
+  ejscreen_raw <- read.csv(local_path)
+
+  ejscreen_vars <- get_census_var_interp_methods(config) %>%
+    filter(dataset == "ejscreen") %>%
+    select(var)
+
+  # "PNPL", "PRMP", "PTSDF", "UST", "PWDIS" come from hydroshare, not here
+  ejscreen_tidy <- ejscreen_raw %>%
+    janitor::clean_names() %>%
+    select(id:region, all_of(ejscreen_vars$var)) %>%
+    mutate(last_epic_run_date = Sys.Date()) %>%
+    # filtering for states/territories we have geoids for
+    filter(!(st_abbrev %in% c("AS", "GU", "MP", "VI")))
+
+  message("Validating raw EJScreen...")
+  validate_raw_ejscreen(config, ejscreen_tidy, dataset_id)
+
+  message("Saving EJScreen dataset to S3...")
+  s3_write_csv(ejscreen_tidy, link)
+}
+
+#' Pointblank validations for raw EJScreen
+validate_raw_ejscreen <- function(config, ejscreen_tidy, dataset_id) {
+  checks_base <- config$metadata$checks_link
+  run_ts <- Sys.time()
+
+  message(sprintf("row_count: %d", nrow(ejscreen_tidy)))
+
+  agent <- new_check_agent(ejscreen_tidy, label = "EJScreen Validation") %>%
+    check_row_count_range(min_rows = 200000, max_rows = 260000, severity = "stop") %>%
+    interrogate()
+
+  result <- summarize_checks(agent)
+  message(sprintf("Validation result summary: %s", result$summary))
+
+  report_link <- write_check_artifacts(
+    agent       = agent,
+    report_df   = result$report_df,
+    checks_base = checks_base,
+    tag         = dataset_id,
+    run_ts      = run_ts
+  )
+  message(sprintf("Validation reports pushed to S3: %s", report_link))
+
+  if (isTRUE(result$any_error)) {
+    stop(sprintf("VALIDATION FAILED: %s", result$summary), call. = FALSE)
+  }
+
+  message("EJScreen validation checks passed successfully.")
+  return(TRUE)
+}
+
+#' Crosswalk EJScreen onto EPA SABs
+#' @param dataset_id "clean_sabs_ejscreen"
+run_clean_sabs_ejscreen_pipeline <- function(config, dataset_id = "clean_sabs_ejscreen") {
+  message(sprintf("Grabbing config variables for dataset %s...", dataset_id))
+  sub_config <- config[[dataset_id]]
+  raw_link <- sub_config$input_links$raw_link
+
+  message("Downloading raw EJScreen from S3...")
+  # coerce_character = FALSE - the score variables need to stay numeric for
+  # the population-weighted interpolation step downstream
+  ejscreen <- s3_read_csv(raw_link, coerce_character = FALSE) %>%
+    mutate(id = as.character(id),
+           geoid_tidy = case_when(nchar(id) < 12 ~ paste0("0", id), TRUE ~ id))
+
+  # need to grab 2022 geometries because I found missing ones in CT 
+  # because: "For 2022, the Census Bureau implemented changes in Connecticut due 
+  # to new county equivalent geographic units." <- based on EJ screen documentation
+  message("Pulling 2022 census block group geometries...")
+  census_block_groups <- tidycensus::get_acs(
+    geography = "block group",
+    variables = c(total_pop = "B01003_001"),
+    state = unique(ejscreen$st_abbrev),
+    year = 2022,
+    geometry = TRUE)
+
+  ejscreen_sf <- merge(ejscreen, census_block_groups,
+                       by.x = "geoid_tidy", by.y = "GEOID") %>%
+    st_as_sf() %>%
+    select(-c(NAME:moe))
+
+  run_sabs_xwalk_pipeline(config, dataset_id, xwalk_dataset_name="ejscreen",
+                           sf_data_census=ejscreen_sf, fips_col = "geoid_tidy",
+                           blocks_2020 = TRUE)
+}

--- a/pipelines/pipeline_epa_sabs.R
+++ b/pipelines/pipeline_epa_sabs.R
@@ -1,0 +1,292 @@
+#' Pull and clean EPA Service Area Boundaries (SABs)
+#' @param config Main config
+#' @param dataset_id "raw_epa_sabs"
+run_epa_sabs_pipeline <- function(config, dataset_id) {
+  epa_sabs <- update_raw_epa_sabs(config, dataset_id)
+
+  message("Running EPA SABs cleaning pipeline...")
+  run_clean_epa_sabs_pipeline(config, "clean_epa_sabs", epa_sabs = epa_sabs)
+
+  message(sprintf("%s pipeline completed successfully.", dataset_id))
+}
+
+#' Pull raw EPA Service Area Boundaries with paginated ArcGIS REST query
+update_raw_epa_sabs <- function(config, dataset_id) {
+  message(sprintf("Grabbing config variables for dataset %s...", dataset_id))
+  sub_config <- config[[dataset_id]]
+  source_url <- sub_config$source_url
+  link <- sub_config$link
+
+  message("Fetching layer metadata from EPA ArcGIS REST API...")
+  layer_metadata <- arcpullr::get_layer_info(paste0(source_url, "/getEstimates"))
+  message(sprintf("Number of records: %d", layer_metadata$count))
+
+  # prepping to paginate using the API:
+  full_count <- layer_metadata$count + 1000  # buffer
+  sabs_data_query <- list()
+  seq_to_loop <- seq(from = 0, to = full_count, by = 500)
+  query_url <- paste0(source_url, "/query")
+
+  message("Paginate API results to avoid hitting hidden limit...")
+  for (i in seq_along(seq_to_loop)) {
+    # find range boundaries
+    range_min <- seq_to_loop[i]
+    range_max <- seq_to_loop[i + 1]
+    # build query
+    query <- list(
+      where = "1=1",
+      outFields = "*",
+      returnGeometry = "true",
+      f = "geojson",
+      resultOffset = range_min,
+      resultRecordCount = 500
+    )
+    # pass request
+    req <- httr::GET(query_url, query = query)
+    full_count_i <- sf::st_read(httr::content(req, "text"), quiet = TRUE)
+
+    if (nrow(full_count_i) == 0) {
+      message(sprintf("No data on page starting at %d - stopping pagination.", range_min))
+      break
+    }
+
+    message(sprintf("Fetched %d - %d (%d records)", range_min, range_max, nrow(full_count_i)))
+    sabs_data_query[[length(sabs_data_query) + 1]] <- full_count_i
+    Sys.sleep(5)
+  }
+
+  message("Combining paginated results...")
+  epa_sabs_all <- do.call(rbind, sabs_data_query)
+
+  message("Checking that everything was captured...")
+  if (nrow(epa_sabs_all) != layer_metadata$count) {
+    stop(sprintf("API QUERY MISSED RECORD: expected %d, got %d.",
+                 layer_metadata$count, nrow(epa_sabs_all)), call. = FALSE)
+  }
+
+  message("Running st_make_valid() for some light tidying...")
+  epa_sabs <- epa_sabs_all %>%
+    janitor::clean_names() %>%
+    mutate(last_epic_run_date = Sys.Date()) %>%
+    st_make_valid()
+
+  message("Validating raw EPA SABs...")
+  validate_raw_epa_sabs(config, dataset_id, epa_sabs)
+
+  message("Saving raw EPA SABs to S3...")
+  s3_write_geojson(epa_sabs, link)
+
+  return(epa_sabs)
+}
+
+#' Pointblank validations for raw EPA SABs
+validate_raw_epa_sabs <- function(config, dataset_id, epa_sabs) {
+  checks_base <- config$metadata$checks_link
+  run_ts <- Sys.time()
+
+  checks_df <- tibble(
+    row_count      = nrow(epa_sabs),
+    geometry_valid = all(sf::st_is_valid(epa_sabs))
+  )
+  print(checks_df)
+
+  agent <- new_check_agent(checks_df, label = "EPA SABs Validation") %>%
+    col_vals_gt(
+      columns = vars(row_count),
+      value = 0,
+      actions = action_levels(stop_at = 1),
+      label = "EPA SABs dataset has > 0 rows"
+    ) %>%
+    col_vals_equal(
+      columns = vars(geometry_valid),
+      value = TRUE,
+      actions = action_levels(warn_at = 1),
+      label = "All geometries are valid"
+    ) %>%
+    interrogate()
+
+  result <- summarize_checks(agent)
+  message(sprintf("Validation result summary: %s", result$summary))
+
+  report_link <- write_check_artifacts(
+    agent       = agent,
+    report_df   = result$report_df,
+    checks_base = checks_base,
+    tag         = dataset_id,
+    run_ts      = run_ts
+  )
+  message(sprintf("Validation reports pushed to S3: %s", report_link))
+
+  if (isTRUE(result$any_error)) {
+    stop(sprintf("VALIDATION FAILED: %s", result$summary), call. = FALSE)
+  }
+
+  message("EPA SABs validation checks passed successfully.")
+  return(TRUE)
+}
+
+#' Light cleaning + state-intersection tagging for EPA SABs
+#' @param config Main config
+#' @param dataset_id "clean_epa_sabs"
+#' @param epa_sabs Optional pre-loaded raw EPA SABs sf object. If NULL, downloaded from S3.
+run_clean_epa_sabs_pipeline <- function(config, dataset_id = "clean_epa_sabs", epa_sabs = NULL) {
+  message(sprintf("Grabbing config variables for dataset %s...", dataset_id))
+  sub_config <- config[[dataset_id]]
+  raw_link <- sub_config$input_links$raw_link
+  link <- sub_config$link
+  pwsid_names_link <- sub_config$pwsid_names_link
+
+  if (is.null(epa_sabs)) {
+    message("Downloading raw EPA SABs from S3...")
+    epa_sabs <- s3_read_geojson(raw_link)
+  }
+
+  message("Simplifying geometries for easier rendering and standardizing names for future merging...")
+  epa_sabs_clean <- epa_sabs %>%
+    st_simplify() %>%
+    mutate(pws_name = str_to_title(pws_name),
+           pws_name = trimws(pws_name),
+           pwsid = trimws(pwsid))
+
+  message("Creating small helper SABs dataframe...")
+  sabs_df <- epa_sabs_clean %>%
+    as.data.frame() %>%
+    select(pwsid, pws_name) %>%
+    arrange(pwsid) %>%
+    unique()
+
+  message("Tagging SABs with intersecting states for easy filtering while avoiding removal of tribal SABs...")
+  sf_use_s2(FALSE)
+  state_pwsid <- st_intersection(epa_sabs_clean, tigris::states() %>%
+                                    st_transform(crs = st_crs(epa_sabs_clean)))
+
+  state_pwsid_summary <- state_pwsid %>%
+    as.data.frame() %>%
+    select(pwsid, STUSPS) %>%
+    rename(state_intersect = STUSPS) %>%
+    group_by(pwsid) %>%
+    # Handles duplicate sabs
+    summarize(states_intersect = paste(unique(state_intersect), collapse = ",")) %>%
+    unique()
+  sf_use_s2(TRUE)
+
+  sabs_df_summary <- merge(sabs_df, state_pwsid_summary, all = TRUE)
+
+  message("Writing intermediary pwsid/name/state-intersection table to S3...")
+  s3_write_csv(sabs_df_summary, pwsid_names_link, acl = "public-read")
+
+  message("Adding state-intersection flags, EWG links, and area...")
+  epa_sabs_final <- merge(epa_sabs_clean,
+                           sabs_df_summary %>% select(-pws_name),
+                           by = "pwsid", all.x = TRUE) %>%
+    rename(epic_states_intersect = states_intersect) %>%
+    relocate(epic_states_intersect, .after = pwsid) %>%
+    mutate(ewg_report_link = paste0("https://www.ewg.org/tapwater/system.php?pws=", pwsid)) %>%
+    relocate(ewg_report_link, .before = last_epic_run_date) %>%
+    # projecting to alberts equal area for st_area calculations 
+    st_transform(crs = 5070)
+
+  epa_sabs_final$epic_area_mi2 <- units::set_units(st_area(epa_sabs_final), "mi^2")
+  epa_sabs_final <- epa_sabs_final %>%
+    relocate(epic_area_mi2, .before = last_epic_run_date) %>%
+    # transform back to original crs of WGS 84
+    st_transform(crs = st_crs(epa_sabs))
+
+  message("Resolving known duplicate/erroneous pwsid records...")
+  epa_sabs_final <- resolve_epa_sabs_duplicates(config, dataset_id, epa_sabs = epa_sabs_final)
+
+  message("Saving clean EPA SABs to S3...")
+  s3_write_geojson(epa_sabs_final, link)
+
+  message(sprintf("%s pipeline completed successfully.", dataset_id))
+}
+
+#' Merge known duplicate pwsids and fix known bad records in cleaned EPA SABs.
+#' 
+#' This can be run as a standalone function and will overwrite the clean
+#' epa_sabs.geojson file if write_to_s3 is set to TRUE.
+#' @param config Main config
+#' @param dataset_id "clean_epa_sabs"
+#' @param epa_sabs Optional pre-loaded, cleaned EPA SABs sf object. If NULL, downloaded from S3.
+#' @param write_to_s3 If TRUE, writes the result back to S3. Defaults to FALSE.
+resolve_epa_sabs_duplicates <- function(config, dataset_id = "clean_epa_sabs", epa_sabs = NULL, write_to_s3 = FALSE) {
+  sub_config <- config[[dataset_id]]
+  link <- sub_config$link
+
+  if (is.null(epa_sabs)) {
+    message("Downloading clean EPA SABs from S3...")
+    epa_sabs <- s3_read_geojson(link)
+  }
+
+  # there are approximately 6 pwsids that are duplicated in this dataset
+  # FL1070685, FL1190789, FL6580531, IA2573701, MT0001923, VA5019052
+  # but confirmed these should just be grouped and merged
+  duplicated_pwsid <- epa_sabs[duplicated(epa_sabs$pwsid), ]
+  dups <- epa_sabs %>%
+    filter(pwsid %in% duplicated_pwsid$pwsid) %>%
+    # this is the one system that has duplicated information, but different
+    # fields. Considering the source of this one is ND water districts and
+    # the EPA data had been updated more recently, I'm opting to remove this
+    # record.
+    filter(pwsid != "ND2801430" & original_data_provider != "NDGISDP-DWR") %>%
+    group_by(pwsid, pws_name) %>%
+    summarize(geometry = st_union(geometry), .groups = "drop") %>%
+    # convert everything to multipolygons to be consistent with all other SABs
+    st_cast("MULTIPOLYGON")
+  # NOTE - there is another SAB with two pwsids pasted together in PR:
+  # pwsid == "PR0005086; PR0005066" and another of ND water systems:
+  # pwsid == ND3401128; ND1001380; ND4801479
+  # pwsid == ND5101125; ND5101065; ND3101807
+
+  if (nrow(dups) == 0) {
+    message("No duplicate pwsids found - skipping duplicate geometry merge.")
+    epa_sabs_final <- epa_sabs
+  } else {
+    message(sprintf("Merging %d duplicated pwsid(s) into single multipolygons...", nrow(dups)))
+
+    # creating a simple data frame to retain key information
+    epa_sabs_df <- epa_sabs %>%
+      filter(pwsid %in% dups$pwsid) %>%
+      as.data.frame() %>%
+      # NOTE - that any pwsids with NAs here had duplicates that needed to be
+      # resolved
+      select(-any_of(c("geometry", "shape_area", "shape_length", "epic_area_mi2", "objectid"))) %>%
+      distinct()
+
+    # merge back with resolved duplicate boundaries
+    dups_sabs <- merge(dups, epa_sabs_df, all.x = TRUE)
+
+    # remove dups from EPA SABs
+    epa_sabs_nodups <- epa_sabs %>%
+      filter(!(pwsid %in% dups$pwsid))
+
+    # adding them back in, and recalculating our area in mi2
+    epa_sabs_tidy <- bind_rows(epa_sabs_nodups, dups_sabs) %>%
+      # projecting to alberts equal area for st_area calculations
+      st_transform(crs = 5070) %>%
+      # removing pwsid == "ND2801430" and original data provider = NDGISDP-DWR
+      # because this pwsid is duplicated
+      filter(!(pwsid == "ND2801430" & original_data_provider == "NDGISDP-DWR"))
+
+    # adding area:
+    epa_sabs_tidy$epic_area_mi2 <- units::set_units(st_area(epa_sabs_tidy), "mi^2")
+    epa_sabs_final <- epa_sabs_tidy %>%
+      relocate(epic_area_mi2, .before = last_epic_run_date) %>%
+      # transform back to original geodetic crs of WGS 84
+      st_transform(crs = st_crs(epa_sabs))
+  }
+
+  epa_sabs_final <- epa_sabs_final %>%
+    # if the pwsid field actually contains multiple water system IDs,
+    # remove the ewg link because it is probably incorrect
+    mutate(ewg_report_link = case_when(grepl("; ", pwsid) ~ NA_character_, TRUE ~ ewg_report_link)) %>%
+    # arrange by pwsid
+    arrange(pwsid)
+
+  if (write_to_s3) {
+    message("Overwriting clean EPA SABs in S3 with resolved duplicates...")
+    s3_write_geojson(epa_sabs_final, link)
+  }
+
+  epa_sabs_final
+}

--- a/pipelines/pipeline_pwsid_environmental_summary.R
+++ b/pipelines/pipeline_pwsid_environmental_summary.R
@@ -1,0 +1,109 @@
+#' Merge the 4 HUC12-level environmental summaries (NPDES, USTs, RMP sites,
+#' impaired waters) into one table.
+#' @param config Main config
+#' @param dataset_id "staged_pwsid_npdes_usts_rmps_imp"
+#' @return HUC12-level environmental summary
+build_huc12_environmental_summary <- function(config, dataset_id = "staged_pwsid_npdes_usts_rmps_imp") {
+  sub_config <- config[[dataset_id]]
+  npdes_link <- sub_config$input_links$npdes_link
+  ust_link <- sub_config$input_links$ust_link
+  rmp_link <- sub_config$input_links$rmp_link
+  imp_waters_link <- sub_config$input_links$imp_waters_link
+
+  # Read numeric columns as-is (coerce_character = FALSE) so replace_na(.x, 0)
+  # below doesn't need a stringify-then-reparse round trip -- only huc12 needs
+  # repair, since read.csv()'s type inference can drop its leading zeros.
+  message("Downloading HUC12 environmental summaries from S3 and fixing HUC12s...")
+  npdes_fixed <- s3_read_csv(npdes_link, coerce_character = FALSE) %>% mutate(huc12 = fix_huc12(huc12))
+  usts_fixed <- s3_read_csv(ust_link, coerce_character = FALSE) %>% mutate(huc12 = fix_huc12(huc12))
+  rmps_fixed <- s3_read_csv(rmp_link, coerce_character = FALSE) %>% mutate(huc12 = fix_huc12(huc12))
+  imp_fixed <- s3_read_csv(imp_waters_link, coerce_character = FALSE) %>%
+    select(-last_epic_run_date) %>%
+    mutate(huc12 = fix_huc12(huc12))
+
+  message("Merging HUC12 environmental summaries...")
+  npdes_fixed %>%
+    full_join(usts_fixed, by = "huc12") %>%
+    full_join(rmps_fixed, by = "huc12") %>%
+    full_join(imp_fixed, by = "huc12") %>%
+    # these are true zeros
+    mutate(across(-huc12, ~ replace_na(.x, 0))) %>%
+    # renaming here to keep the hookup the same for CNT
+    rename(
+      open_usts = total_open_usts,
+      tos_usts = total_tos_usts,
+      total_open_usts = epa_open_usts
+    )
+}
+
+#' Merge NPDES/USTs/RMP sites/impaired waters HUC12-level summaries and roll
+#' them up to pwsid level, staging the result for the tool.
+#' A pwsid can have multiple rows if it draws from multiple HUC12s.
+#' @param config Main config
+#' @param dataset_id "staged_pwsid_npdes_usts_rmps_imp"
+run_staged_pwsid_npdes_usts_rmps_imp_pipeline <- function(config, dataset_id = "staged_pwsid_npdes_usts_rmps_imp") {
+  message(sprintf("Grabbing config variables for dataset %s...", dataset_id))
+  sub_config <- config[[dataset_id]]
+  staged_link <- sub_config$staged_link
+
+  huc12_env_summary <- build_huc12_environmental_summary(config, dataset_id)
+
+  message("Downloading intake/well HUC12 table for pwsid/HUC12 facility counts...")
+  intake_wells_long <- get_tidy_intake_wells(config, "clean_pwsid_intake_well_huc12")
+
+  env_cols <- setdiff(names(huc12_env_summary), "huc12")
+
+  message("Counting intake/well facilities per pwsid/HUC12 pair...")
+  pwsid_huc12_facilities <- intake_wells_long %>%
+    group_by(pwsid, huc12) %>%
+    summarize(num_facilities = n_distinct(facility_id), .groups = "drop") %>%
+    left_join(huc12_env_summary, by = "huc12") %>%
+    # a pwsid/HUC12 pair with no match just means zero of that hazard type
+    mutate(across(all_of(env_cols), ~ replace_na(.x, 0)))
+
+  message("Validating staged_pwsid_npdes_usts_rmps_imp...")
+  validate_staged_pwsid_npdes_usts_rmps_imp(config, pwsid_huc12_facilities, dataset_id)
+
+  message("Writing staged dataset to S3...")
+  s3_write_csv(pwsid_huc12_facilities, staged_link, acl = "public-read")
+
+  message(sprintf("%s pipeline completed successfully.", dataset_id))
+  return(pwsid_huc12_facilities)
+}
+
+#' Pointblank validations for the staged pwsid-level environmental summary
+#' @param config Main config
+#' @param pwsid_huc12_facilities pwsid/HUC12-level environmental summary
+#' @param dataset_id "staged_pwsid_npdes_usts_rmps_imp"
+validate_staged_pwsid_npdes_usts_rmps_imp <- function(config, pwsid_huc12_facilities, dataset_id) {
+  checks_base <- config$metadata$checks_link
+  run_ts <- Sys.time()
+
+  print(as_tibble(pwsid_huc12_facilities))
+
+  agent <- new_check_agent(pwsid_huc12_facilities, label = "Staged PWSID Environmental Validation") %>%
+    check_column_complete(pwsid, severity = "stop") %>%
+    check_column_complete(huc12, severity = "stop") %>%
+    rows_distinct(
+      columns = vars(pwsid, huc12),
+      actions = action_levels(stop_at = 1),
+      label = "No duplicate pwsid/HUC12 pairs"
+    ) %>%
+    interrogate()
+
+  result <- summarize_checks(agent)
+  message(sprintf("Validation result summary: %s", result$summary))
+
+  report_link <- write_check_artifacts(
+    agent = agent, report_df = result$report_df,
+    checks_base = checks_base, tag = dataset_id, run_ts = run_ts
+  )
+  message(sprintf("Validation reports pushed to S3: %s", report_link))
+
+  if (isTRUE(result$any_error)) {
+    stop(sprintf("VALIDATION FAILED: %s", result$summary), call. = FALSE)
+  }
+
+  message("Staged PWSID environmental hazard rollup validation checks passed successfully.")
+  return(TRUE)
+}

--- a/pipelines/pipeline_sabs_socioeconomic_merge.R
+++ b/pipelines/pipeline_sabs_socioeconomic_merge.R
@@ -1,0 +1,44 @@
+# Shared crosswalk step for datasets that get interpolated onto EPA Service
+# Area Boundaries (SVI, CEJST, EJScreen) using xwalk_census_geo_sabs().
+# Each dataset's own pipeline file handles its dataset-specific raw pull and
+# prep, then calls run_sabs_xwalk_pipeline() to do the shared crosswalk +
+# write step.
+#
+# get_census_var_interp_methods() lives in functions/pipeline_helpers.R.
+
+#' Crosswalk a census-geometry dataset onto EPA SABs and write the result
+#' @param config Main config
+#' @param dataset_id The "clean_X_xwalk" dataset_id (for config + registry)
+#' @param xwalk_dataset_name The value of the `dataset` column in the
+#'   interpolation methods sheet (e.g. "svi", "cejst", "ejscreen")
+#' @param sf_data_census sf object of the prepped census-geometry dataset
+#' @param fips_col The fips column name in sf_data_census
+#' @param blocks_2020 Whether to use 2020 or 2010 census blocks as weights
+run_sabs_xwalk_pipeline <- function(config, dataset_id, xwalk_dataset_name,
+                                     sf_data_census, fips_col, blocks_2020) {
+  message(sprintf("Grabbing config variables for dataset %s...", dataset_id))
+  sub_config <- config[[dataset_id]]
+  sabs_link <- sub_config$input_links$sabs_link
+  link <- sub_config$link
+
+  message("Downloading clean EPA SABs from S3...")
+  epa_sabs <- s3_read_geojson(sabs_link)
+
+  message(sprintf("Grabbing interpolation methods for %s...", xwalk_dataset_name))
+  interp_methods <- get_census_var_interp_methods(config) %>%
+    filter(dataset == xwalk_dataset_name)
+
+  message(sprintf("Crosswalking %s onto SABs...", xwalk_dataset_name))
+  sab_xwalk <- xwalk_census_geo_sabs(epa_sabs, sf_data_census, interp_methods,
+                                     blocks_2020 = blocks_2020, fips_col = fips_col,
+                                     save_data = FALSE)
+
+  sab_xwalk_df <- sab_xwalk %>%
+    as.data.frame() %>%
+    select(-starts_with("geom"))
+
+  message("Saving crosswalked dataset to S3...")
+  s3_write_csv(sab_xwalk_df, link)
+
+  message(sprintf("%s pipeline completed successfully.", dataset_id))
+}

--- a/pipelines/pipeline_svi.R
+++ b/pipelines/pipeline_svi.R
@@ -1,0 +1,120 @@
+################################################################################
+# SVI has no public download API, so it must be downloaded by hand before
+# this pipeline can run.
+# 
+# Steps:
+# 1. Go to the CDC/ATSDR SVI data download page:
+#    https://www.atsdr.cdc.gov/place-health/php/svi/svi-data-documentation-download.html
+# 2. Set these parameters:
+#      - Year:           2022
+#      - Geography:      United States
+#      - Geography Type: Census Tracts
+#      - File Type:      ESRI Geodatabase
+# 3. Download the zip and unzip it. It contains a File Geodatabase folder
+#    named "SVI2022_US_tract.gdb".
+# 4. Place that folder at ./data/SVI2022_US_tract.gdb (relative to the repo
+#    root), matching raw_svi.local_source_path in main_config.json.
+################################################################################
+
+#' Pull CDC/ATSDR Social Vulnerability Index and crosswalk onto EPA SABs
+#' @param config Main config
+#' @param dataset_id "raw_svi"
+run_svi_pipeline <- function(config, dataset_id) {
+  update_raw_svi(config, dataset_id)
+
+  message("Running SABs and SVI crosswalk pipeline...")
+  run_clean_sabs_svi_pipeline(config, "clean_sabs_svi")
+
+  message(sprintf("%s pipeline completed successfully.", dataset_id))
+}
+
+#' Read, clean, and validate locally downloaded SVI geodatabase
+update_raw_svi <- function(config, dataset_id) {
+  message(sprintf("Grabbing config variables for dataset %s...", dataset_id))
+  sub_config <- config[[dataset_id]]
+  local_path <- sub_config$local_source_path
+  link <- sub_config$link
+
+  if (!file.exists(local_path)) {
+    stop(sprintf(
+      "SVI source file not found at %s. Follow download steps in pipeline_svi.R.",
+      local_path
+    ), call. = FALSE)
+  }
+
+  message("Reading local SVI geodatabase...")
+  svi_raw <- st_read(local_path, layer = "SVI2022_US_Tract", quiet = TRUE)
+
+  svi_vars <- get_census_var_interp_methods(config) %>%
+    filter(dataset == "svi") %>%
+    select(var)
+
+  # E_LIMENG = persons age >5 who speak English less than well
+  # E_MOBILE = mobile home estimates
+  # RPL_THEMES = overall percentile ranking summary variable and
+  # disaggregated themes
+  svi_tidy <- svi_raw %>%
+    janitor::clean_names() %>%
+    select(st:location, all_of(svi_vars$var)) %>%
+    mutate(last_epic_run_date = Sys.Date()) %>%
+    rename(geography = Shape)
+
+  message("Validating raw SVI...")
+  validate_raw_svi(config, svi_tidy, dataset_id)
+
+  message("Saving SVI dataset to S3...")
+  s3_write_geojson(svi_tidy, link)
+}
+
+#' Pointblank validations for raw SVI
+validate_raw_svi <- function(config, svi_tidy, dataset_id) {
+  checks_base <- config$metadata$checks_link
+  run_ts <- Sys.time()
+
+  message(sprintf("row_count: %d", nrow(svi_tidy)))
+  attrs <- sf::st_drop_geometry(svi_tidy)
+
+  agent <- new_check_agent(attrs, label = "SVI Validation") %>%
+    check_row_count_range(min_rows = 70000, max_rows = 90000, severity = "stop") %>%
+    interrogate()
+
+  result <- summarize_checks(agent)
+  message(sprintf("Validation result summary: %s", result$summary))
+
+  report_link <- write_check_artifacts(
+    agent       = agent,
+    report_df   = result$report_df,
+    checks_base = checks_base,
+    tag         = dataset_id,
+    run_ts      = run_ts
+  )
+  message(sprintf("Validation reports pushed to S3: %s", report_link))
+
+  if (isTRUE(result$any_error)) {
+    stop(sprintf("VALIDATION FAILED: %s", result$summary), call. = FALSE)
+  }
+
+  message("SVI validation checks passed successfully.")
+  return(TRUE)
+}
+
+#' Crosswalk SVI onto EPA SABs
+#' @param dataset_id "clean_sabs_svi"
+run_clean_sabs_svi_pipeline <- function(config, dataset_id = "clean_sabs_svi") {
+  message(sprintf("Grabbing config variables for dataset %s...", dataset_id))
+  sub_config <- config[[dataset_id]]
+  raw_link <- sub_config$input_links$raw_link
+
+  message("Downloading raw SVI from S3...")
+  svi <- s3_read_geojson(raw_link) %>%
+    # a value of -999 means it was unavailable/uncalculated in the source
+    # data - treat as NA rather than a real value so it isn't interpolated
+    # as actual -999s
+    mutate(across(rpl_theme1:rpl_themes, ~ case_when(. < 0 ~ NA, TRUE ~ .)))
+
+  # NOTE - the documentation doesn't explicitly say what census vintage is used, 
+  # but it uses ACS 2022 5yr estimate, so I'm assuming 2020 
+  run_sabs_xwalk_pipeline(config, dataset_id, xwalk_dataset_name="svi",
+                           svi, fips_col = "fips",
+                           blocks_2020 = TRUE)
+}

--- a/pipelines/pipeline_ust.R
+++ b/pipelines/pipeline_ust.R
@@ -98,8 +98,7 @@ validate_raw_ust <- function(config, ust_tidy, dataset_id) {
 
   result <- summarize_checks(agent)
   message(sprintf("Validation result summary: %s", result$summary))
-  print(get_agent_report(agent))
-  
+
   # Write HTML report and CSV to S3
   report_link <- write_check_artifacts(
     agent       = agent, 

--- a/scripts/sync_main_config.R
+++ b/scripts/sync_main_config.R
@@ -1,0 +1,112 @@
+###############################################################################
+# This script merges the local version of main_config.json with the S3 version
+# since this file can be edited and pushed to AWS by multiple people.
+# 
+# The merged local copy unions the dataset_ids, merges the "triggers" array as
+# sets, and flags fields with different values. A merge summary is output to
+# show any merge conflicts. Once these conflicts are fixed, the new local
+# version can be pushed to AWS using the printed aws command.
+#
+# Run from the repo root with command: Rscript scripts/sync_main_config.R
+###############################################################################
+
+library(jsonlite)
+
+source("functions/s3_client.R")
+set_s3_bucket("tech-team-data")
+
+LOCAL_CONFIG_PATH <- "main_config.json"
+S3_CONFIG_KEY <- "national-dw-tool/development/pipeline-config/main_config.json"
+
+# jsonlite (simplifyVector = FALSE) parses {} as names = character(0) and []
+# as names = NULL, so checking names() is how we tell object vs array apart
+.is_json_object <- function(x) {
+  is.list(x) && !is.null(names(x)) && all(names(x) != "")
+}
+
+.is_json_array_of_scalars <- function(x) {
+  is.list(x) && length(x) > 0 && (is.null(names(x)) || any(names(x) == "")) &&
+    all(vapply(x, function(el) !is.list(el) && length(el) == 1, logical(1)))
+}
+
+#' Recursively merge two parsed config trees
+#' returns list(merged = ..., conflicts = list of path/local/remote for
+#' anything that couldn't just be unioned)
+.merge_config <- function(local, remote, path = character(0)) {
+  conflicts <- list()
+
+  if (.is_json_object(local) && .is_json_object(remote)) {
+    all_names <- union(names(local), names(remote))
+    # keep it named even when empty, otherwise an empty object roundtrips
+    # as [] instead of {} once write_json gets to it
+    merged <- setNames(list(), character(0))
+    for (nm in all_names) {
+      sub_path <- c(path, nm)
+      if (!(nm %in% names(local))) {
+        merged[[nm]] <- remote[[nm]]
+      } else if (!(nm %in% names(remote))) {
+        merged[[nm]] <- local[[nm]]
+      } else {
+        result <- .merge_config(local[[nm]], remote[[nm]], sub_path)
+        merged[[nm]] <- result$merged
+        conflicts <- c(conflicts, result$conflicts)
+      }
+    }
+    return(list(merged = merged, conflicts = conflicts))
+  }
+
+  if (.is_json_array_of_scalars(local) && .is_json_array_of_scalars(remote)) {
+    local_vals <- unlist(local, use.names = FALSE)
+    remote_vals <- unlist(remote, use.names = FALSE)
+    return(list(merged = as.list(union(local_vals, remote_vals)), conflicts = list()))
+  }
+
+  if (identical(local, remote)) {
+    return(list(merged = local, conflicts = list()))
+  }
+
+  conflicts <- list(list(path = paste(path, collapse = "."), local_value = local, remote_value = remote))
+  list(merged = local, conflicts = conflicts)
+}
+
+message(sprintf("Reading local config: %s", LOCAL_CONFIG_PATH))
+local_config <- jsonlite::fromJSON(LOCAL_CONFIG_PATH, simplifyVector = FALSE)
+
+message(sprintf("Grabbing remote config from S3: %s", S3_CONFIG_KEY))
+tmp <- tempfile(fileext = ".json")
+s3_client()$download_file(Bucket = s3_bucket(), Key = S3_CONFIG_KEY, Filename = tmp)
+remote_config <- jsonlite::fromJSON(tmp, simplifyVector = FALSE)
+unlink(tmp)
+
+result <- .merge_config(local_config, remote_config)
+merged_config <- result$merged
+conflicts <- result$conflicts
+
+message("Merge summary:")
+only_local <- setdiff(names(local_config), names(remote_config))
+only_remote <- setdiff(names(remote_config), names(local_config))
+if (length(only_local) > 0) {
+  message(sprintf("  only in local (kept): %s", paste(only_local, collapse = ", ")))
+}
+if (length(only_remote) > 0) {
+  message(sprintf("  only in remote (added): %s", paste(only_remote, collapse = ", ")))
+}
+if (length(only_local) == 0 && length(only_remote) == 0) {
+  message("  no dataset entries added or removed on either side")
+}
+
+if (length(conflicts) > 0) {
+  message(sprintf("  %d conflict(s) - kept local copy, manually verify:", length(conflicts)))
+  for (c in conflicts) {
+    message(sprintf("    %s", c$path))
+    message(sprintf("      local:  %s", jsonlite::toJSON(c$local_value, auto_unbox = TRUE)))
+    message(sprintf("      remote: %s", jsonlite::toJSON(c$remote_value, auto_unbox = TRUE)))
+  }
+} else {
+  message("  no conflicts, everything either merged cleanly or matched")
+}
+
+jsonlite::write_json(merged_config, LOCAL_CONFIG_PATH, auto_unbox = TRUE, pretty = TRUE, null = "null")
+message(sprintf("Wrote merged config to %s.", LOCAL_CONFIG_PATH))
+message("Once merge conflicts are fixed, push the merged local copy to S3 using:")
+message(sprintf("  aws s3 cp %s s3://tech-team-data/%s", LOCAL_CONFIG_PATH, S3_CONFIG_KEY))


### PR DESCRIPTION
- pipeline_pwsid_environmental_merge - migrates code from 2_summarize_data.Rmd which merges environmental datasets for staging
- pipeline_epa_sabs - migrates code from worker sabs_yearly.R and 2_summarize_data.Rmd which pulls raw EPA SABs data with multiple steps of cleaning. The resolve_epa_sabs_duplicates() function can be updated and run as a standalone function for any manual updates that need to overwrite the epa_sabs.geojson file.
- pipeline_cejst, pipeline_ejscreen, and pipeline_svi - migrates code from 2_summarize_data.Rmd for CEJST, EJSCREEN, and SVI datasets respectively

Note:
- The only pipeline I was unable to fully test was raw_ejscreen. The download link through Harvard Dataverse kept running into the "504 Gateway Time-out" error.
- All other pipelines completed successfully during local testing

Progress on #33