### PR TITLE
Migrate the remaining BWN state workers to the ETL pipeline (#38)

### DIFF
--- a/functions/bwn_helpers.R
+++ b/functions/bwn_helpers.R
@@ -96,6 +96,34 @@ read_prior_bwn <- function(link, bucket = s3_bucket()) {
   s3_read_csv(link, bucket = bucket, coerce_character = FALSE)
 }
 
+#' Drop scraped rows that carry no identity at all.
+#' rvest's html_table(fill = TRUE) renders a header-only table as a single row
+#' of NAs. Left alone, the reconcile sees a key of NA/NA/NA, finds it absent
+#' from the baseline, and files it as a brand new advisory: a system-less,
+#' date-less record that is written to the dataset and on into the national
+#' summary, where it never ages out because it keeps matching itself.
+#' This is a routine state, not an edge case. A state page with no active
+#' notices publishes exactly this. The legacy Florida worker guarded against it
+#' with an if() over a vector, which only worked when the scrape produced
+#' exactly one new row; this is the same intent expressed so it works for any
+#' number of rows.
+#' @param df Fresh scrape
+#' @param id_cols Columns that together identify a real advisory
+#' @return df without the rows in which every id_col is missing
+drop_empty_scraped_rows <- function(df, id_cols) {
+  present <- intersect(id_cols, names(df))
+  if (!length(present) || !nrow(df)) return(df)
+  blank <- Reduce(`&`, lapply(present, function(col) {
+    v <- as.character(df[[col]])
+    is.na(v) | trimws(v) == ""
+  }))
+  if (any(blank)) {
+    message(sprintf("Dropping %d scraped row(s) with no %s.",
+                    sum(blank), paste(present, collapse = " or ")))
+  }
+  df[!blank, , drop = FALSE]
+}
+
 #' Ensure the columns the reconcile step maintains exist on a fresh pull.
 #' @param df Fresh pull
 #' @return Data frame with bwn_managed_cols present
@@ -249,8 +277,14 @@ reconcile_bwn_rolling_window <- function(fresh, old, key_cols, update_key_cols) 
 #' @param pwsid_col Name of the system-id column in the RAW data. Most states use
 #'   "pwsid", but Missouri's source calls it "pws_id" until the clean step
 #'   renames it.
+#' @param pwsid_severity Severity of the system-id completeness check. Defaults
+#'   to "stop". Some sources publish only a system NAME, so their worker joins to
+#'   sabs_pwsid_names by name and keeps the rows that do not match (Washington
+#'   matches roughly a third of its rows). For those states this is "warning":
+#'   an unmatched advisory is still a real advisory the national summary has to
+#'   count, so dropping it would undercount, and stopping would abort every run.
 validate_raw_bwn <- function(config, bwn, bwn_old, dataset_id, label,
-                             pwsid_col = "pwsid") {
+                             pwsid_col = "pwsid", pwsid_severity = "stop") {
   checks_base <- config$metadata$checks_link
   run_ts <- Sys.time()
   n_old <- if (is.null(bwn_old)) 0 else nrow(bwn_old)
@@ -283,7 +317,7 @@ validate_raw_bwn <- function(config, bwn, bwn_old, dataset_id, label,
       actions = action_levels(stop_at = 1),
       label = sprintf("no row loss vs the previous run (%d rows)", n_old)
     ) %>%
-    check_column_all_true(system_id_present, severity = "stop") %>%
+    check_column_all_true(system_id_present, severity = pwsid_severity) %>%
     interrogate()
 
   .report_bwn_checks(agent, checks_base, dataset_id, run_ts)
@@ -295,7 +329,11 @@ validate_raw_bwn <- function(config, bwn, bwn_old, dataset_id, label,
 #' @param bwn_clean Standardized BWN data
 #' @param dataset_id e.g. "clean_ak_bwn"
 #' @param label Human-readable agent label
-validate_clean_bwn <- function(config, bwn_clean, dataset_id, label) {
+#' @param pwsid_severity Severity of the pwsid completeness check. See
+#'   validate_raw_bwn(); the name-joined states pass "warning" here for the same
+#'   reason.
+validate_clean_bwn <- function(config, bwn_clean, dataset_id, label,
+                               pwsid_severity = "stop") {
   checks_base <- config$metadata$checks_link
   run_ts <- Sys.time()
 
@@ -305,7 +343,7 @@ validate_clean_bwn <- function(config, bwn_clean, dataset_id, label) {
     )
 
   agent <- new_check_agent(checks_df, label = label) %>%
-    check_column_complete(pwsid, severity = "stop") %>%
+    check_column_complete(pwsid, severity = pwsid_severity) %>%
     check_column_complete(date_issued, severity = "warning") %>%
     check_column_all_true(lifted_flag_valid, severity = "stop") %>%
     interrogate()

--- a/main_config.json
+++ b/main_config.json
@@ -770,6 +770,228 @@
     "date_range": "1 year ending 2026-08-06",
     "quality_check_link": "national-dw-tool/validation/clean_la_bwa_1yr_report.html"
   },
+  "raw_me_bwn": {
+    "triggers": [
+      "clean_me_bwn"
+    ],
+    "clean_name": "Maine Boil Water Notices",
+    "update_freq": "daily (automatic)",
+    "category": "water-system",
+    "link": "national-dw-tool/raw/me/water-system/me_bwn.csv",
+    "staged_link": "N/A",
+    "input_links": {
+      "pwsid_names_link": "national-dw-tool/raw/national/water-system/sabs_pwsid_names.csv"
+    },
+    "source": "Maine CDC",
+    "source_url": "https://www.maine.gov/dhhs/mecdc/healthy-living/health-safety/drinking-water-safety/information-for-consumers/drinking-water-safety-alerts",
+    "spatial_level": "State",
+    "date_range": "N/A",
+    "quality_check_link": "national-dw-tool/validation/raw_me_bwn_report.html"
+  },
+  "clean_me_bwn": {
+    "triggers": [
+      "merged_national_bwn_summary"
+    ],
+    "bwn_state_label": "Maine",
+    "clean_name": "Maine Boil Water Notices (Standardized)",
+    "update_freq": "daily (automatic)",
+    "category": "water-system",
+    "link": "national-dw-tool/clean/me/me_bwn.csv",
+    "staged_link": "N/A",
+    "input_links": {
+      "raw_link": "national-dw-tool/raw/me/water-system/me_bwn.csv"
+    },
+    "source": "N/A",
+    "source_url": "N/A",
+    "spatial_level": "State",
+    "date_range": "N/A",
+    "quality_check_link": "national-dw-tool/validation/clean_me_bwn_report.html"
+  },
+  "raw_wa_bwn": {
+    "triggers": [
+      "clean_wa_bwn"
+    ],
+    "clean_name": "Washington Boil Water Notices",
+    "update_freq": "daily (automatic)",
+    "category": "water-system",
+    "link": "national-dw-tool/raw/wa/water-system/wa_bwn.csv",
+    "staged_link": "N/A",
+    "input_links": {
+      "pwsid_names_link": "national-dw-tool/raw/national/water-system/sabs_pwsid_names.csv"
+    },
+    "source": "Washington State Department of Health",
+    "source_url": "https://doh.wa.gov/community-and-environment/drinking-water/active-alerts?county=All&combine=",
+    "spatial_level": "State",
+    "date_range": "N/A",
+    "quality_check_link": "national-dw-tool/validation/raw_wa_bwn_report.html"
+  },
+  "clean_wa_bwn": {
+    "triggers": [
+      "merged_national_bwn_summary"
+    ],
+    "bwn_state_label": "Washington",
+    "clean_name": "Washington Boil Water Notices (Standardized)",
+    "update_freq": "daily (automatic)",
+    "category": "water-system",
+    "link": "national-dw-tool/clean/wa/wa_bwn.csv",
+    "staged_link": "N/A",
+    "input_links": {
+      "raw_link": "national-dw-tool/raw/wa/water-system/wa_bwn.csv"
+    },
+    "source": "N/A",
+    "source_url": "N/A",
+    "spatial_level": "State",
+    "date_range": "N/A",
+    "quality_check_link": "national-dw-tool/validation/clean_wa_bwn_report.html"
+  },
+  "raw_ar_bwn": {
+    "triggers": [
+      "clean_ar_bwn"
+    ],
+    "clean_name": "Arkansas Boil Water Notices",
+    "update_freq": "daily (automatic)",
+    "category": "water-system",
+    "link": "national-dw-tool/raw/ar/water-system/ar_bwn.csv",
+    "staged_link": "N/A",
+    "input_links": {
+      "pwsid_names_link": "national-dw-tool/raw/national/water-system/sabs_pwsid_names.csv"
+    },
+    "source": "Arkansas Department of Health",
+    "source_url": "https://health.arkansas.gov/wa_engTraining/boilwaterorder.aspx",
+    "spatial_level": "State",
+    "date_range": "N/A",
+    "quality_check_link": "national-dw-tool/validation/raw_ar_bwn_report.html"
+  },
+  "clean_ar_bwn": {
+    "triggers": [
+      "merged_national_bwn_summary"
+    ],
+    "bwn_state_label": "Arkansas",
+    "clean_name": "Arkansas Boil Water Notices (Standardized)",
+    "update_freq": "daily (automatic)",
+    "category": "water-system",
+    "link": "national-dw-tool/clean/ar/ar_bwn.csv",
+    "staged_link": "N/A",
+    "input_links": {
+      "raw_link": "national-dw-tool/raw/ar/water-system/ar_bwn.csv"
+    },
+    "source": "N/A",
+    "source_url": "N/A",
+    "spatial_level": "State",
+    "date_range": "N/A",
+    "quality_check_link": "national-dw-tool/validation/clean_ar_bwn_report.html"
+  },
+  "raw_or_bwn": {
+    "triggers": [
+      "clean_or_bwn"
+    ],
+    "clean_name": "Oregon Boil Water Notices",
+    "update_freq": "quarterly (automatic)",
+    "category": "water-system",
+    "link": "national-dw-tool/raw/or/water-system/or_bwn.csv",
+    "staged_link": "N/A",
+    "input_links": {
+      "pwsid_names_link": "national-dw-tool/raw/national/water-system/sabs_pwsid_names.csv"
+    },
+    "source": "Oregon Health Authority",
+    "source_url": "https://yourwater.oregon.gov/advisories.php?areasw=x&areap=x&popa=x&popv=x&open=x&lifted=x&begin=&end=&sort=start",
+    "spatial_level": "State",
+    "date_range": "N/A",
+    "quality_check_link": "national-dw-tool/validation/raw_or_bwn_report.html"
+  },
+  "clean_or_bwn": {
+    "triggers": [
+      "merged_national_bwn_summary"
+    ],
+    "bwn_state_label": "Oregon",
+    "clean_name": "Oregon Boil Water Notices (Standardized)",
+    "update_freq": "quarterly (automatic)",
+    "category": "water-system",
+    "link": "national-dw-tool/clean/or/or_bwn.csv",
+    "staged_link": "N/A",
+    "input_links": {
+      "raw_link": "national-dw-tool/raw/or/water-system/or_bwn.csv"
+    },
+    "source": "N/A",
+    "source_url": "N/A",
+    "spatial_level": "State",
+    "date_range": "N/A",
+    "quality_check_link": "national-dw-tool/validation/clean_or_bwn_report.html"
+  },
+  "raw_nm_bwn": {
+    "triggers": [
+      "clean_nm_bwn"
+    ],
+    "clean_name": "New Mexico Boil Water Notices",
+    "update_freq": "quarterly (automatic)",
+    "category": "water-system",
+    "link": "national-dw-tool/raw/nm/water-system/nm_bwn.csv",
+    "staged_link": "N/A",
+    "input_links": {
+      "pwsid_names_link": "national-dw-tool/raw/national/water-system/sabs_pwsid_names.csv"
+    },
+    "source": "New Mexico Environment Department",
+    "source_url": "https://www.env.nm.gov/drinking_water/boil-water-advisories/",
+    "spatial_level": "State",
+    "date_range": "N/A",
+    "quality_check_link": "national-dw-tool/validation/raw_nm_bwn_report.html"
+  },
+  "clean_nm_bwn": {
+    "triggers": [
+      "merged_national_bwn_summary"
+    ],
+    "bwn_state_label": "New Mexico",
+    "clean_name": "New Mexico Boil Water Notices (Standardized)",
+    "update_freq": "quarterly (automatic)",
+    "category": "water-system",
+    "link": "national-dw-tool/clean/nm/nm_bwn.csv",
+    "staged_link": "N/A",
+    "input_links": {
+      "raw_link": "national-dw-tool/raw/nm/water-system/nm_bwn.csv"
+    },
+    "source": "N/A",
+    "source_url": "N/A",
+    "spatial_level": "State",
+    "date_range": "N/A",
+    "quality_check_link": "national-dw-tool/validation/clean_nm_bwn_report.html"
+  },
+  "raw_fl_bwn": {
+    "triggers": [
+      "clean_fl_bwn"
+    ],
+    "clean_name": "Florida Boil Water Notices",
+    "update_freq": "quarterly (automatic)",
+    "category": "water-system",
+    "link": "national-dw-tool/raw/fl/water-system/fl_bwn.csv",
+    "staged_link": "N/A",
+    "input_links": {
+      "pwsid_names_link": "national-dw-tool/raw/national/water-system/sabs_pwsid_names.csv"
+    },
+    "source": "Florida Department of Health",
+    "source_url": "https://www.floridahealth.gov/community-environmental-public-health/emergency-preparedness-response/boil-water-notices/",
+    "spatial_level": "State",
+    "date_range": "N/A",
+    "quality_check_link": "national-dw-tool/validation/raw_fl_bwn_report.html"
+  },
+  "clean_fl_bwn": {
+    "triggers": [
+      "merged_national_bwn_summary"
+    ],
+    "bwn_state_label": "Florida",
+    "clean_name": "Florida Boil Water Notices (Standardized)",
+    "update_freq": "quarterly (automatic)",
+    "category": "water-system",
+    "link": "national-dw-tool/clean/fl/fl_bwn.csv",
+    "staged_link": "N/A",
+    "input_links": {
+      "raw_link": "national-dw-tool/raw/fl/water-system/fl_bwn.csv"
+    },
+    "source": "N/A",
+    "source_url": "N/A",
+    "spatial_level": "State",
+    "date_range": "N/A",
+    "quality_check_link": "national-dw-tool/validation/clean_fl_bwn_report.html"
+  },
   "merged_national_bwn_summary": {
     "triggers": [
       "merged_national_highlevel_summary"

--- a/main_runner.R
+++ b/main_runner.R
@@ -148,6 +148,18 @@ pipeline_router <- list(
   "clean_la_bwa_1yr" = function(config, dataset_id) {
     run_clean_la_bwn_pipeline(config, dataset_id, state_label = "Louisiana - BWA, 1yr")
   },
+  "raw_me_bwn" = run_me_bwn_pipeline,
+  "clean_me_bwn" = run_clean_me_bwn_pipeline,
+  "raw_wa_bwn" = run_wa_bwn_pipeline,
+  "clean_wa_bwn" = run_clean_wa_bwn_pipeline,
+  "raw_ar_bwn" = run_ar_bwn_pipeline,
+  "clean_ar_bwn" = run_clean_ar_bwn_pipeline,
+  "raw_or_bwn" = run_or_bwn_pipeline,
+  "clean_or_bwn" = run_clean_or_bwn_pipeline,
+  "raw_nm_bwn" = run_nm_bwn_pipeline,
+  "clean_nm_bwn" = run_clean_nm_bwn_pipeline,
+  "raw_fl_bwn" = run_fl_bwn_pipeline,
+  "clean_fl_bwn" = run_clean_fl_bwn_pipeline,
   "merged_national_bwn_summary" = run_merged_national_bwn_summary_pipeline,
   "merged_national_highlevel_summary" = run_merged_national_highlevel_summary_pipeline
 )

--- a/pipelines/pipeline_ar_bwn.R
+++ b/pipelines/pipeline_ar_bwn.R
@@ -1,0 +1,149 @@
+###############################################################################
+# Arkansas Boil Water Notices (issue #38)
+# Migrated from 1_downloaders/daily/ar_worker/ar_daily.R
+#
+# Arkansas Health publishes a boil water order table that carries its own
+# rescind dates, so this is a rolling window rather than an active feed: an
+# advisory can come back with a lift date filled in, and records that age off
+# the page must be retained from our own history. Lift dates are real, so
+# epic_date_lifted_flag is "Reported".
+#
+# Like Washington, the source publishes no system id, so pwsid is recovered by
+# joining to the EPA SABs name list and the advisory is keyed on the system
+# NAME. The pwsid completeness checks therefore run at warning severity.
+#
+# Shared BWN helpers live in functions/bwn_helpers.R.
+###############################################################################
+
+# Texarkana straddles the state line and appears in the SABs list under both
+# states. Dropping the Texas id keeps the name join from matching twice.
+ar_excluded_pwsid <- "TX0190004"
+
+#' Pull Arkansas BWN data, then run the AR BWN clean pipeline
+#' @param config Main config
+#' @param dataset_id "raw_ar_bwn"
+run_ar_bwn_pipeline <- function(config, dataset_id) {
+  update_raw_ar_bwn(config, dataset_id)
+
+  message(sprintf("%s pipeline completed successfully.", dataset_id))
+}
+
+#' Fetch, reconcile against the previous run, validate, and save raw AR BWN data
+#' @param config Main config
+#' @param dataset_id "raw_ar_bwn"
+#' @return Reconciled raw BWN data frame
+update_raw_ar_bwn <- function(config, dataset_id) {
+  message(sprintf("Grabbing config variables for dataset %s...", dataset_id))
+  sub_config <- config[[dataset_id]]
+  source_url <- sub_config$source_url
+  link <- sub_config$link
+  pwsid_names_link <- sub_config$input_links$pwsid_names_link
+
+  message("Scraping the Arkansas Health boil water order page...")
+  tables <- rvest::read_html(source_url) %>%
+    rvest::html_nodes("table") %>%
+    rvest::html_table(fill = TRUE)
+
+  if (length(tables) < 1) {
+    stop(sprintf(
+      "AR BWN: no boil water order table found on %s. The page layout has probably changed.",
+      source_url), call. = FALSE)
+  }
+
+  ar_bwn <- tables[[1]] %>%
+    janitor::clean_names() %>%
+    # the legacy worker had no guard here, so a header-only page would be filed
+    # as a new advisory with no system and no dates
+    drop_empty_scraped_rows(c("system", "county")) %>%
+    # normalized here because this doubles as the join key to the SABs name list
+    mutate(system = str_squish(str_to_title(system)))
+
+  message("Recovering pwsids by system name from the EPA SABs name list...")
+  epa_sabs_pwsids <- s3_read_csv(pwsid_names_link)
+  ar_pwsids <- epa_sabs_pwsids %>%
+    filter(pwsid != ar_excluded_pwsid) %>%
+    filter(grepl("AR", states_intersect))
+
+  ar_bwn_tidy <- merge(ar_bwn, ar_pwsids, by.x = "system",
+                       by.y = "pws_name", all.x = TRUE) %>%
+    mutate(last_epic_run_date = as.character(Sys.Date()))
+
+  matched <- sum(!is.na(ar_bwn_tidy$pwsid))
+  message(sprintf("Matched %d of %d scraped advisories to a pwsid.",
+                  matched, nrow(ar_bwn_tidy)))
+
+  message("Reading the previous run for reconciliation...")
+  ar_bwn_old <- read_prior_bwn(link)
+
+  ar_bwn_reconciled <- reconcile_ar_bwn(ar_bwn_tidy, ar_bwn_old)
+
+  message("Validating raw_ar_bwn...")
+  validate_raw_bwn(config, ar_bwn_reconciled, ar_bwn_old, dataset_id,
+                   label = "AR Boil Water Notice Validation",
+                   pwsid_severity = "warning")
+
+  message(sprintf("Writing raw_ar_bwn to S3 to %s...", link))
+  s3_write_csv(ar_bwn_reconciled, link)
+
+  return(ar_bwn_reconciled)
+}
+
+#' Reconcile a fresh Arkansas pull against the previous run.
+#' Keys on two ids because the source is a rolling window:
+#'   full_id   = system + date_issued + date_lifted  (a specific version)
+#'   update_id = system + date_issued                (the advisory itself)
+#' A row whose update_id matches but whose full_id does not is the same advisory
+#' with a lift date now reported, so the fresh version replaces the stored one.
+#' @param ar_bwn_tidy Fresh pull, tidied
+#' @param ar_bwn_old Previous raw pull, or NULL on a first run
+#' @return Combined data frame
+reconcile_ar_bwn <- function(ar_bwn_tidy, ar_bwn_old) {
+  reconcile_bwn_rolling_window(
+    ar_bwn_tidy, ar_bwn_old,
+    key_cols        = c("system", "date_issued", "date_lifted"),
+    update_key_cols = c("system", "date_issued")
+  )
+}
+
+#' Standardize AR BWN into the shared cross-state BWN schema
+#' @param config Main config
+#' @param dataset_id "clean_ar_bwn"
+#' @param bwn_raw Optional pre-loaded raw BWN data. If NULL, downloaded from S3.
+run_clean_ar_bwn_pipeline <- function(config, dataset_id = "clean_ar_bwn",
+                                      bwn_raw = NULL) {
+  message(sprintf("Grabbing config variables for dataset %s...", dataset_id))
+  sub_config <- config[[dataset_id]]
+  raw_link <- sub_config$input_links$raw_link
+  link <- sub_config$link
+
+  if (is.null(bwn_raw)) {
+    message("Downloading raw AR BWN from S3...")
+    bwn_raw <- s3_read_csv(raw_link)
+  }
+
+  message("Standardizing to the shared BWN schema...")
+  ar_bwn_clean <- bwn_raw %>%
+    # the source stamps these with a time as well ("8/3/2026 4:27:45 PM");
+    # strptime ignores the unmatched tail, leaving the date
+    mutate(date_issued = as.Date(date_issued, tryFormats = c("%m/%d/%Y")),
+           date_lifted = as.Date(date_lifted, tryFormats = c("%m/%d/%Y")),
+           last_epic_run_date = as.Date(last_epic_run_date,
+                                        tryFormats = c("%Y-%m-%d")),
+           # the page carries no reason or advisory-type column
+           type = "No Information",
+           # Arkansas reports real rescind dates
+           epic_date_lifted_flag = "Reported",
+           state = "Arkansas") %>%
+    finalize_bwn_clean()
+
+  message("Validating clean_ar_bwn...")
+  validate_clean_bwn(config, ar_bwn_clean, dataset_id,
+                     label = "AR BWN Clean Validation",
+                     pwsid_severity = "warning")
+
+  message(sprintf("Writing clean_ar_bwn to S3 to %s...", link))
+  s3_write_csv(ar_bwn_clean, link)
+
+  message(sprintf("%s pipeline completed successfully.", dataset_id))
+  return(ar_bwn_clean)
+}

--- a/pipelines/pipeline_fl_bwn.R
+++ b/pipelines/pipeline_fl_bwn.R
@@ -1,0 +1,174 @@
+###############################################################################
+# Florida Boil Water Notices (issue #38)
+# Migrated from 1_downloaders/quarterly/fl_worker/fl_quarterly.R
+#
+# Florida Health publishes a notice table carrying its own rescind dates, so this
+# is a rolling window: an advisory can come back with its rescind date filled in,
+# and notices that drop off the page are retained from our own history.
+# epic_date_lifted_flag is "Reported".
+#
+# Three deliberate differences from the legacy worker, all called out in the PR:
+#
+#  1. The legacy worker never joined a pwsid at all. The column only existed in
+#     the stored file, so every genuinely new notice was written with a missing
+#     system id, and a first run into an empty bucket would produce a dataset
+#     with no pwsid column for the clean step to standardize. Florida publishes
+#     only a system name, so pwsid is recovered from the EPA SABs name list the
+#     same way Washington, Arkansas and New Mexico do. The completeness checks
+#     run at warning severity for the same reason they do there.
+#
+#  2. The legacy guard that dropped the all-NA row of a header-only page was an
+#     if() over a vector, so it only worked when the scrape produced exactly one
+#     new row. Its intent is kept via drop_empty_scraped_rows(), applied to the
+#     scrape. Florida's page is header-only whenever no notice is active, so
+#     without this the reconcile files a system-less, date-less "advisory" that
+#     then never ages out of the national summary.
+#
+#  3. The legacy clean step could emit epic_date_lifted_flag =
+#     "Assumed for this one record", which is outside the two values the national
+#     summary contract allows. That case is mapped to "Assumed", which is what it
+#     means; the explanation stays in the comments column.
+#
+# Shared BWN helpers live in functions/bwn_helpers.R.
+###############################################################################
+
+# Marker the team writes into comments when a notice disappeared from the page
+# without a rescind date and one was filled in by hand
+fl_assumed_rescind_marker <- "EPIC ASSUMED DATE RESCINDED"
+
+#' Pull Florida BWN data, then run the FL BWN clean pipeline
+#' @param config Main config
+#' @param dataset_id "raw_fl_bwn"
+run_fl_bwn_pipeline <- function(config, dataset_id) {
+  update_raw_fl_bwn(config, dataset_id)
+
+  message(sprintf("%s pipeline completed successfully.", dataset_id))
+}
+
+#' Fetch, reconcile against the previous run, validate, and save raw FL BWN data
+#' @param config Main config
+#' @param dataset_id "raw_fl_bwn"
+#' @return Reconciled raw BWN data frame
+update_raw_fl_bwn <- function(config, dataset_id) {
+  message(sprintf("Grabbing config variables for dataset %s...", dataset_id))
+  sub_config <- config[[dataset_id]]
+  source_url <- sub_config$source_url
+  link <- sub_config$link
+  pwsid_names_link <- sub_config$input_links$pwsid_names_link
+
+  message("Scraping the Florida Health boil water notice page...")
+  tables <- rvest::read_html(source_url) %>%
+    rvest::html_nodes("table") %>%
+    rvest::html_table(fill = TRUE)
+
+  if (length(tables) < 1) {
+    stop(sprintf(
+      "FL BWN: no notice table found on %s. The page layout has probably changed.",
+      source_url), call. = FALSE)
+  }
+
+  fl_bwn <- tables[[1]] %>%
+    janitor::clean_names() %>%
+    # Florida's page is header-only whenever no notice is active, and
+    # html_table(fill = TRUE) renders that as one row of NAs. Without this the
+    # reconcile files that row as a new advisory. See drop_empty_scraped_rows().
+    drop_empty_scraped_rows(c("system_name", "county")) %>%
+    # normalized here because this doubles as the join key to the SABs name list
+    mutate(system_name = str_squish(str_to_title(system_name)))
+
+  message("Recovering pwsids by system name from the EPA SABs name list...")
+  epa_sabs_pwsids <- s3_read_csv(pwsid_names_link)
+  fl_pwsids <- epa_sabs_pwsids %>% filter(grepl("FL", states_intersect))
+
+  fl_bwn_tidy <- merge(fl_bwn, fl_pwsids, by.x = "system_name",
+                       by.y = "pws_name", all.x = TRUE) %>%
+    mutate(last_epic_run_date = as.character(Sys.Date()))
+
+  matched <- sum(!is.na(fl_bwn_tidy$pwsid))
+  message(sprintf("Matched %d of %d scraped notices to a pwsid.",
+                  matched, nrow(fl_bwn_tidy)))
+
+  message("Reading the previous run for reconciliation...")
+  fl_bwn_old <- read_prior_bwn(link)
+
+  fl_bwn_reconciled <- reconcile_fl_bwn(fl_bwn_tidy, fl_bwn_old)
+
+  message("Validating raw_fl_bwn...")
+  validate_raw_bwn(config, fl_bwn_reconciled, fl_bwn_old, dataset_id,
+                   label = "FL Boil Water Notice Validation",
+                   pwsid_severity = "warning")
+
+  message(sprintf("Writing raw_fl_bwn to S3 to %s...", link))
+  s3_write_csv(fl_bwn_reconciled, link)
+
+  return(fl_bwn_reconciled)
+}
+
+#' Reconcile a fresh Florida pull against the previous run.
+#' Keys on two ids because the source is a rolling window:
+#'   full_id   = system_name + date_issued + date_rescinded
+#'   update_id = system_name + date_issued
+#' A row whose update_id matches but whose full_id does not is the same notice
+#' with a rescind date now reported, so the fresh version replaces the stored one.
+#'
+#' The legacy worker guarded its bind with
+#'   if (is.na(new_records$system_name) & is.na(new_records$county))
+#' which evaluates a vector in an if(): with no new notices that is logical(0)
+#' and errors, and with two or more rows it errors as well. Its INTENT, dropping
+#' the all-NA row that a header-only page produces, is preserved, but it is
+#' applied to the scrape itself via drop_empty_scraped_rows() so it works for any
+#' number of rows rather than only when the scrape yields exactly one.
+#' @param fl_bwn_tidy Fresh pull, tidied
+#' @param fl_bwn_old Previous raw pull, or NULL on a first run
+#' @return Combined data frame
+reconcile_fl_bwn <- function(fl_bwn_tidy, fl_bwn_old) {
+  reconcile_bwn_rolling_window(
+    fl_bwn_tidy, fl_bwn_old,
+    key_cols        = c("system_name", "date_issued", "date_rescinded"),
+    update_key_cols = c("system_name", "date_issued")
+  )
+}
+
+#' Standardize FL BWN into the shared cross-state BWN schema
+#' @param config Main config
+#' @param dataset_id "clean_fl_bwn"
+#' @param bwn_raw Optional pre-loaded raw BWN data. If NULL, downloaded from S3.
+run_clean_fl_bwn_pipeline <- function(config, dataset_id = "clean_fl_bwn",
+                                      bwn_raw = NULL) {
+  message(sprintf("Grabbing config variables for dataset %s...", dataset_id))
+  sub_config <- config[[dataset_id]]
+  raw_link <- sub_config$input_links$raw_link
+  link <- sub_config$link
+
+  if (is.null(bwn_raw)) {
+    message("Downloading raw FL BWN from S3...")
+    bwn_raw <- s3_read_csv(raw_link)
+  }
+
+  message("Standardizing to the shared BWN schema...")
+  fl_bwn_clean <- bwn_raw %>%
+    mutate(date_issued = as.Date(date_issued, tryFormats = c("%m/%d/%Y")),
+           date_lifted = as.Date(date_rescinded, tryFormats = c("%m/%d/%Y")),
+           last_epic_run_date = as.Date(last_epic_run_date,
+                                        tryFormats = c("%Y-%m-%d")),
+           type = "Assumed - Boil Water Notices",
+           # Florida reports rescind dates, except where a notice vanished from
+           # the page without one and the date was filled in by hand. See the
+           # header note on the flag value.
+           epic_date_lifted_flag = case_when(
+             grepl(fl_assumed_rescind_marker, comments) ~ "Assumed",
+             TRUE ~ "Reported"),
+           state = "Florida") %>%
+    finalize_bwn_clean()
+
+  message("Validating clean_fl_bwn...")
+  validate_clean_bwn(config, fl_bwn_clean, dataset_id,
+                     label = "FL BWN Clean Validation",
+                     pwsid_severity = "warning")
+
+  message(sprintf("Writing clean_fl_bwn to S3 to %s...", link))
+  s3_write_csv(fl_bwn_clean, link)
+
+  message(sprintf("%s pipeline completed successfully.", dataset_id))
+  return(fl_bwn_clean)
+}

--- a/pipelines/pipeline_me_bwn.R
+++ b/pipelines/pipeline_me_bwn.R
@@ -1,0 +1,155 @@
+###############################################################################
+# Maine Boil Water Notices (issue #38)
+# Migrated from 1_downloaders/daily/me_worker/me_daily.R
+#
+# Maine's CDC publishes its drinking water safety alerts as a set of HTML tables,
+# one per order type (boil water, do not drink, and occasionally do not use).
+# Only advisories currently in effect are listed, so this is an active feed: a
+# record disappearing implies it was lifted, and we date that closure to the day
+# we noticed it ("Assumed"). Unlike Alaska, the order type is not a single
+# constant, it comes from which table the row was scraped out of.
+#
+# Shared BWN helpers live in functions/bwn_helpers.R.
+###############################################################################
+
+# The alert tables in the order Maine publishes them. The third is only present
+# when a do-not-use order is active, which is why the count is not assumed.
+me_bwn_table_types <- c("Boil Water Order", "Do Not Drink Order",
+                        "Do Not Use Order")
+
+#' Pull Maine BWN data, then run the ME BWN clean pipeline
+#' @param config Main config
+#' @param dataset_id "raw_me_bwn"
+run_me_bwn_pipeline <- function(config, dataset_id) {
+  update_raw_me_bwn(config, dataset_id)
+
+  message(sprintf("%s pipeline completed successfully.", dataset_id))
+}
+
+#' Fetch, reconcile against the previous run, validate, and save raw ME BWN data
+#' @param config Main config
+#' @param dataset_id "raw_me_bwn"
+#' @return Reconciled raw BWN data frame
+update_raw_me_bwn <- function(config, dataset_id) {
+  message(sprintf("Grabbing config variables for dataset %s...", dataset_id))
+  sub_config <- config[[dataset_id]]
+  source_url <- sub_config$source_url
+  link <- sub_config$link
+  pwsid_names_link <- sub_config$input_links$pwsid_names_link
+
+  message("Scraping the Maine CDC drinking water safety alerts page...")
+  tables <- rvest::read_html(source_url) %>%
+    rvest::html_nodes("table") %>%
+    rvest::html_table(fill = TRUE)
+
+  # The boil-water and do-not-drink tables are always published. Failing here
+  # with the count is far easier to diagnose than a subscript error if Maine
+  # restructures the page.
+  if (length(tables) < 2) {
+    stop(sprintf(
+      "ME BWN: expected at least 2 alert tables on %s, found %d. The page layout has probably changed.",
+      source_url, length(tables)), call. = FALSE)
+  }
+
+  # Tag each table with the order type it represents, then stack them. Maine
+  # publishes boil water first and do not drink second; the legacy worker bound
+  # them in the order do-not-drink, boil-water, do-not-use, which is preserved
+  # here so a first run in an empty bucket reproduces the legacy row order.
+  # Legacy took the do-not-use table only when the page had exactly three
+  # tables, dropping it otherwise, so an unexpected fourth table is ignored
+  # rather than being mislabelled as a do-not-use order.
+  n_tables <- if (length(tables) == length(me_bwn_table_types))
+    length(me_bwn_table_types) else 2L
+  parsed <- lapply(seq_len(n_tables), function(i) {
+    tables[[i]] %>%
+      as.data.frame() %>%
+      janitor::clean_names() %>%
+      dplyr::mutate(type = me_bwn_table_types[i]) %>%
+      dplyr::mutate(dplyr::across(dplyr::everything(), as.character))
+  })
+  names(parsed) <- me_bwn_table_types[seq_len(n_tables)]
+  me_bwn <- dplyr::bind_rows(parsed[["Do Not Drink Order"]],
+                             parsed[["Boil Water Order"]],
+                             parsed[["Do Not Use Order"]])
+
+  message("Filtering to community water systems...")
+  epa_sabs_pwsids <- s3_read_csv(pwsid_names_link)
+
+  me_bwn_tidy <- me_bwn %>%
+    # a handful of systems are listed as "community" on the state page but do
+    # not match a pwsid in the EPA SABs dataset, and their names do not match
+    # either, so there is nothing to join them on
+    filter(pwsid %in% epa_sabs_pwsids$pwsid) %>%
+    # keep Maine's own rendering ("Apr 11, 2026") and derive the ISO date from it
+    rename(date_issued_me = date_issued) %>%
+    mutate(last_epic_run_date = as.character(Sys.Date()),
+           date_issued = as.character(lubridate::mdy(date_issued_me)))
+
+  message("Reading the previous run for reconciliation...")
+  me_bwn_old <- read_prior_bwn(link)
+
+  me_bwn_reconciled <- reconcile_me_bwn(me_bwn_tidy, me_bwn_old)
+
+  message("Validating raw_me_bwn...")
+  validate_raw_bwn(config, me_bwn_reconciled, me_bwn_old, dataset_id,
+                   label = "ME Boil Water Notice Validation")
+
+  message(sprintf("Writing raw_me_bwn to S3 to %s...", link))
+  s3_write_csv(me_bwn_reconciled, link)
+
+  return(me_bwn_reconciled)
+}
+
+#' Reconcile a fresh Maine pull against the previous run.
+#' Maine lists only advisories currently in effect, so this uses the shared
+#' active-feed reconcile. An advisory is identified by system, issue date and
+#' reason: one system can hold concurrent orders issued the same day for
+#' different reasons.
+#' @param me_bwn_tidy Fresh pull, tidied
+#' @param me_bwn_old Previous raw pull, or NULL on a first run
+#' @return Combined data frame
+reconcile_me_bwn <- function(me_bwn_tidy, me_bwn_old) {
+  reconcile_bwn_active_feed(
+    me_bwn_tidy, me_bwn_old,
+    key_cols = c("pwsid", "date_issued", "reason")
+  )
+}
+
+#' Standardize ME BWN into the shared cross-state BWN schema
+#' @param config Main config
+#' @param dataset_id "clean_me_bwn"
+#' @param bwn_raw Optional pre-loaded raw BWN data. If NULL, downloaded from S3.
+run_clean_me_bwn_pipeline <- function(config, dataset_id = "clean_me_bwn",
+                                      bwn_raw = NULL) {
+  message(sprintf("Grabbing config variables for dataset %s...", dataset_id))
+  sub_config <- config[[dataset_id]]
+  raw_link <- sub_config$input_links$raw_link
+  link <- sub_config$link
+
+  if (is.null(bwn_raw)) {
+    message("Downloading raw ME BWN from S3...")
+    bwn_raw <- s3_read_csv(raw_link)
+  }
+
+  message("Standardizing to the shared BWN schema...")
+  me_bwn_clean <- bwn_raw %>%
+    mutate(date_issued = as.Date(date_issued, tryFormats = c("%Y-%m-%d")),
+           date_lifted = as.Date(date_lifted, tryFormats = c("%Y-%m-%d")),
+           last_epic_run_date = as.Date(last_epic_run_date,
+                                        tryFormats = c("%Y-%m-%d")),
+           # Maine publishes only active advisories, so every closure we record
+           # is inferred rather than reported. See the header note.
+           epic_date_lifted_flag = "Assumed",
+           state = "Maine") %>%
+    finalize_bwn_clean()
+
+  message("Validating clean_me_bwn...")
+  validate_clean_bwn(config, me_bwn_clean, dataset_id,
+                     label = "ME BWN Clean Validation")
+
+  message(sprintf("Writing clean_me_bwn to S3 to %s...", link))
+  s3_write_csv(me_bwn_clean, link)
+
+  message(sprintf("%s pipeline completed successfully.", dataset_id))
+  return(me_bwn_clean)
+}

--- a/pipelines/pipeline_national_bwn_summary.R
+++ b/pipelines/pipeline_national_bwn_summary.R
@@ -63,7 +63,7 @@ run_merged_national_bwn_summary_pipeline <- function(config, dataset_id = "merge
     select(all_of(bwn_contract_cols))
 
   message(sprintf("Downloading existing national BWN summary from %s...", link))
-  bwn_summary_old <- read_prior_merged_csv(link)
+  bwn_summary_old <- read_existing_merged_csv(link)
 
   if (nrow(bwn_summary_old) == 0) {
     other_states_rows <- bwn_summary_old

--- a/pipelines/pipeline_nm_bwn.R
+++ b/pipelines/pipeline_nm_bwn.R
@@ -1,0 +1,196 @@
+###############################################################################
+# New Mexico Boil Water Notices (issue #38)
+# Migrated from 1_downloaders/quarterly/nm_worker/nm_quarterly.R
+#
+# New Mexico publishes one HTML table whose status column carries the lift date
+# in prose ("Lifted on 09/21/2023"), so lift dates are real and this is a rolling
+# window: epic_date_lifted_flag is "Reported" and records that drop off the page
+# are retained from our own history.
+#
+# The system id is not a column. Older rows embed one or two pwsids in the system
+# name in parentheses; newer rows stopped doing that, so those are matched to the
+# EPA SABs name list instead. Some rows match neither, which is why the pwsid
+# completeness checks run at warning severity.
+#
+# Shared BWN helpers live in functions/bwn_helpers.R.
+###############################################################################
+
+# The published table has no usable header row of its own
+nm_bwn_col_names <- c("water_system", "county", "advisory_issue_date", "status")
+
+# A pwsid the state publishes incorrectly; EPA SABs has the correct one
+nm_pwsid_corrections <- c("NM355518" = "NM3535518")
+
+#' Pull New Mexico BWN data, then run the NM BWN clean pipeline
+#' @param config Main config
+#' @param dataset_id "raw_nm_bwn"
+run_nm_bwn_pipeline <- function(config, dataset_id) {
+  update_raw_nm_bwn(config, dataset_id)
+
+  message(sprintf("%s pipeline completed successfully.", dataset_id))
+}
+
+#' Fetch, reconcile against the previous run, validate, and save raw NM BWN data
+#' @param config Main config
+#' @param dataset_id "raw_nm_bwn"
+#' @return Reconciled raw BWN data frame
+update_raw_nm_bwn <- function(config, dataset_id) {
+  message(sprintf("Grabbing config variables for dataset %s...", dataset_id))
+  sub_config <- config[[dataset_id]]
+  source_url <- sub_config$source_url
+  link <- sub_config$link
+  pwsid_names_link <- sub_config$input_links$pwsid_names_link
+
+  message("Scraping the New Mexico Environment Department advisories page...")
+  tables <- rvest::read_html(source_url) %>%
+    rvest::html_nodes("table") %>%
+    rvest::html_table(fill = TRUE)
+
+  if (length(tables) < 1) {
+    stop(sprintf(
+      "NM BWN: no advisory table found on %s. The page layout has probably changed.",
+      source_url), call. = FALSE)
+  }
+  page_data <- tables[[1]]
+  if (ncol(page_data) < length(nm_bwn_col_names)) {
+    stop(sprintf(
+      "NM BWN: advisory table has %d columns, expected at least %d. The page layout has probably changed.",
+      ncol(page_data), length(nm_bwn_col_names)), call. = FALSE)
+  }
+  if (nrow(page_data) < 2) {
+    stop(sprintf(
+      "NM BWN: advisory table has %d row(s), so there is nothing below the header row on %s.",
+      nrow(page_data), source_url), call. = FALSE)
+  }
+  names(page_data)[seq_along(nm_bwn_col_names)] <- nm_bwn_col_names
+  # the first row repeats the column names rather than carrying data. Guarded
+  # above: with a header-only table, 2:nrow() would be c(2, 1) and promote the
+  # label row into the data.
+  nm_bwn <- page_data[2:nrow(page_data), ]
+
+  # System names look like "Some Water System (NM1234567)" and occasionally carry
+  # two ids. Splitting on the parentheses yields up to four pieces.
+  nm_bwn_sep <- nm_bwn %>%
+    tidyr::separate(water_system,
+                    into = c("name_one", "pwsid_one", "name_two", "pwsid_two"),
+                    sep = "\\(|\\)", fill = "right", extra = "drop")
+
+  # rows that carry their pwsid inline: pivot the two id slots into rows
+  bwn_pwsids <- nm_bwn_sep %>%
+    filter(!is.na(pwsid_one)) %>%
+    tidyr::pivot_longer(cols = c("pwsid_one", "pwsid_two")) %>%
+    filter(!is.na(value)) %>%
+    mutate(water_system_name = paste0(name_one, name_two)) %>%
+    select(-c(name_one:name_two)) %>%
+    relocate(water_system_name) %>%
+    rename(pwsid = value, pwsid_number = name) %>%
+    relocate(pwsid, .after = water_system_name)
+
+  # rows with no inline pwsid, recovered by name against the EPA SABs list
+  bwn_no_pwsids <- nm_bwn_sep %>%
+    filter(is.na(pwsid_one)) %>%
+    mutate(name_one = trimws(name_one))
+
+  message("Recovering pwsids by system name from the EPA SABs name list...")
+  epa_sabs_pwsids <- s3_read_csv(pwsid_names_link)
+  nm_pwsids <- epa_sabs_pwsids %>% filter(grepl("NM", states_intersect))
+
+  bwn_no_pwsids_merged <- merge(nm_pwsids, bwn_no_pwsids, by.x = "pws_name",
+                                by.y = "name_one", all.y = TRUE) %>%
+    select(-c(pwsid_one:pwsid_two)) %>%
+    rename(water_system_name = pws_name)
+
+  nm_bwn_tidy <- bind_rows(bwn_pwsids, bwn_no_pwsids_merged) %>%
+    mutate(
+      # The legacy worker chose between "%m/%d/%Y" and "%m/%d/%y" on nchar().
+      # mdy() handles both two- and four-digit years directly and does not
+      # depend on which row happens to come first, which as.Date(tryFormats=)
+      # does. Verified to reproduce every stored issued_date_clean exactly.
+      issued_date_clean = lubridate::mdy(advisory_issue_date),
+      status_clean = case_when(grepl("Lifted", status) ~ "Lifted"),
+      # the lift date is embedded in prose, e.g. "Lifted on 09/21/2023"
+      lifted_date_clean = str_extract(status, "\\d{1,2}/\\d{1,2}/\\d{4}"),
+      lifted_date_clean = as.Date(lifted_date_clean, "%m/%d/%Y"),
+      # named-vector lookup returns NA for anything not being corrected (and for
+      # a missing pwsid), so coalesce falls back to the original value
+      pwsid = coalesce(unname(nm_pwsid_corrections[pwsid]), pwsid)) %>%
+    mutate(last_epic_run_date = as.character(Sys.Date()))
+
+  matched <- sum(!is.na(nm_bwn_tidy$pwsid))
+  message(sprintf("Matched %d of %d scraped advisories to a pwsid.",
+                  matched, nrow(nm_bwn_tidy)))
+
+  message("Reading the previous run for reconciliation...")
+  nm_bwn_old <- read_prior_bwn(link)
+
+  nm_bwn_reconciled <- reconcile_nm_bwn(nm_bwn_tidy, nm_bwn_old)
+
+  message("Validating raw_nm_bwn...")
+  validate_raw_bwn(config, nm_bwn_reconciled, nm_bwn_old, dataset_id,
+                   label = "NM Boil Water Notice Validation",
+                   pwsid_severity = "warning")
+
+  message(sprintf("Writing raw_nm_bwn to S3 to %s...", link))
+  s3_write_csv(nm_bwn_reconciled, link)
+
+  return(nm_bwn_reconciled)
+}
+
+#' Reconcile a fresh New Mexico pull against the previous run.
+#' Keys on two ids because the source is a rolling window:
+#'   full_id   = pwsid + issued_date_clean + lifted_date_clean
+#'   update_id = pwsid + issued_date_clean
+#' A row whose update_id matches but whose full_id does not is the same advisory
+#' with a lift date now reported, so the fresh version replaces the stored one.
+#' @param nm_bwn_tidy Fresh pull, tidied
+#' @param nm_bwn_old Previous raw pull, or NULL on a first run
+#' @return Combined data frame
+reconcile_nm_bwn <- function(nm_bwn_tidy, nm_bwn_old) {
+  reconcile_bwn_rolling_window(
+    nm_bwn_tidy, nm_bwn_old,
+    key_cols        = c("pwsid", "issued_date_clean", "lifted_date_clean"),
+    update_key_cols = c("pwsid", "issued_date_clean")
+  )
+}
+
+#' Standardize NM BWN into the shared cross-state BWN schema
+#' @param config Main config
+#' @param dataset_id "clean_nm_bwn"
+#' @param bwn_raw Optional pre-loaded raw BWN data. If NULL, downloaded from S3.
+run_clean_nm_bwn_pipeline <- function(config, dataset_id = "clean_nm_bwn",
+                                      bwn_raw = NULL) {
+  message(sprintf("Grabbing config variables for dataset %s...", dataset_id))
+  sub_config <- config[[dataset_id]]
+  raw_link <- sub_config$input_links$raw_link
+  link <- sub_config$link
+
+  if (is.null(bwn_raw)) {
+    message("Downloading raw NM BWN from S3...")
+    bwn_raw <- s3_read_csv(raw_link)
+  }
+
+  message("Standardizing to the shared BWN schema...")
+  nm_bwn_clean <- bwn_raw %>%
+    rename(date_issued = issued_date_clean,
+           date_lifted = lifted_date_clean) %>%
+    mutate(date_issued = as.Date(date_issued, tryFormats = c("%Y-%m-%d")),
+           date_lifted = as.Date(date_lifted, tryFormats = c("%Y-%m-%d")),
+           last_epic_run_date = as.Date(last_epic_run_date,
+                                        tryFormats = c("%Y-%m-%d")),
+           # New Mexico states the lift date in the status column
+           epic_date_lifted_flag = "Reported",
+           type = "Assumed - Boil Water Advisories",
+           state = "New Mexico") %>%
+    finalize_bwn_clean()
+
+  message("Validating clean_nm_bwn...")
+  validate_clean_bwn(config, nm_bwn_clean, dataset_id,
+                     label = "NM BWN Clean Validation",
+                     pwsid_severity = "warning")
+
+  message(sprintf("Writing clean_nm_bwn to S3 to %s...", link))
+  s3_write_csv(nm_bwn_clean, link)
+
+  message(sprintf("%s pipeline completed successfully.", dataset_id))
+  return(nm_bwn_clean)
+}

--- a/pipelines/pipeline_or_bwn.R
+++ b/pipelines/pipeline_or_bwn.R
@@ -1,0 +1,165 @@
+###############################################################################
+# Oregon Boil Water Notices (issue #38)
+# Migrated from 1_downloaders/quarterly/or_worker/or_quarterly.R
+#
+# Oregon's advisory portal lists open and lifted advisories together with real
+# lift dates, so this is a rolling window: an advisory already in our records can
+# come back with its lift date filled in, and records that drop off the listing
+# are retained from our own history. epic_date_lifted_flag is "Reported".
+#
+# Oregon's tracking began in May 2017, so the clean step drops the single
+# pre-2017 record rather than presenting a partial year.
+#
+# Shared BWN helpers live in functions/bwn_helpers.R.
+###############################################################################
+
+# The portal renders the table with the filter options appended to each header,
+# so the columns are renamed positionally. Note "affcted_populations": the
+# misspelling is carried forward deliberately, it is the stored column name.
+or_bwn_col_names <- c("regulating_agency", "county_served", "pws", "pws_name",
+                      "system_type", "population", "primary_source",
+                      "advisory_type", "reason", "begin_date", "date_lifted",
+                      "area_affected", "affcted_populations")
+
+# Oregon writes an open advisory's lift date as this sentinel rather than a blank
+or_open_sentinel <- "Open"
+
+#' Pull Oregon BWN data, then run the OR BWN clean pipeline
+#' @param config Main config
+#' @param dataset_id "raw_or_bwn"
+run_or_bwn_pipeline <- function(config, dataset_id) {
+  update_raw_or_bwn(config, dataset_id)
+
+  message(sprintf("%s pipeline completed successfully.", dataset_id))
+}
+
+#' Fetch, reconcile against the previous run, validate, and save raw OR BWN data
+#' @param config Main config
+#' @param dataset_id "raw_or_bwn"
+#' @return Reconciled raw BWN data frame
+update_raw_or_bwn <- function(config, dataset_id) {
+  message(sprintf("Grabbing config variables for dataset %s...", dataset_id))
+  sub_config <- config[[dataset_id]]
+  source_url <- sub_config$source_url
+  link <- sub_config$link
+  pwsid_names_link <- sub_config$input_links$pwsid_names_link
+
+  message("Scraping the Oregon drinking water advisory portal...")
+  tables <- rvest::read_html(source_url) %>%
+    rvest::html_nodes("table") %>%
+    rvest::html_table(fill = TRUE)
+
+  # the advisories are in the second table; the first is the filter form
+  if (length(tables) < 2) {
+    stop(sprintf(
+      "OR BWN: expected at least 2 tables on %s, found %d. The page layout has probably changed.",
+      source_url, length(tables)), call. = FALSE)
+  }
+  bwn <- tables[[2]]
+  if (ncol(bwn) < length(or_bwn_col_names)) {
+    stop(sprintf(
+      "OR BWN: advisory table has %d columns, expected at least %d. The page layout has probably changed.",
+      ncol(bwn), length(or_bwn_col_names)), call. = FALSE)
+  }
+  names(bwn)[seq_along(or_bwn_col_names)] <- or_bwn_col_names
+  or_bwn <- bwn[, seq_along(or_bwn_col_names)]
+
+  or_bwn_tidy <- or_bwn %>%
+    # the listing carries one row with no system number
+    filter(!is.na(pws)) %>%
+    # the portal reports a bare system number, so rebuild the pwsid: zero-pad it
+    # to five digits and prefix Oregon's "OR41". pmax guards a number longer than
+    # five digits, which would make strrep() error; such a value simply fails the
+    # SABs membership filter below.
+    mutate(pwsid_char = as.character(pws),
+           pwsid = paste0("OR41", strrep("0", pmax(0, 5 - nchar(pwsid_char))),
+                          pwsid_char)) %>%
+    select(-pwsid_char) %>%
+    relocate(pwsid, .before = pws) %>%
+    # some community systems on this listing are absent from the EPA SABs
+    # database and so have no boundary to attach an advisory to
+    filter(pwsid %in% s3_read_csv(pwsid_names_link)$pwsid) %>%
+    mutate(last_epic_run_date = as.character(Sys.Date()))
+
+  message("Reading the previous run for reconciliation...")
+  or_bwn_old <- read_prior_bwn(link)
+
+  or_bwn_reconciled <- reconcile_or_bwn(or_bwn_tidy, or_bwn_old)
+
+  message("Validating raw_or_bwn...")
+  validate_raw_bwn(config, or_bwn_reconciled, or_bwn_old, dataset_id,
+                   label = "OR Boil Water Notice Validation")
+
+  message(sprintf("Writing raw_or_bwn to S3 to %s...", link))
+  s3_write_csv(or_bwn_reconciled, link)
+
+  return(or_bwn_reconciled)
+}
+
+#' Reconcile a fresh Oregon pull against the previous run.
+#' Keys on two ids because the source is a rolling window:
+#'   full_id   = pwsid + advisory_type + begin_date + date_lifted
+#'   update_id = pwsid + advisory_type + begin_date
+#' A row whose update_id matches but whose full_id does not is the same advisory
+#' with a lift date now reported, so the fresh version replaces the stored one.
+#' advisory_type is part of the identity because one system can hold a boil water
+#' and a do-not-drink advisory beginning the same day.
+#' @param or_bwn_tidy Fresh pull, tidied
+#' @param or_bwn_old Previous raw pull, or NULL on a first run
+#' @return Combined data frame
+reconcile_or_bwn <- function(or_bwn_tidy, or_bwn_old) {
+  reconcile_bwn_rolling_window(
+    or_bwn_tidy, or_bwn_old,
+    key_cols        = c("pwsid", "advisory_type", "begin_date", "date_lifted"),
+    update_key_cols = c("pwsid", "advisory_type", "begin_date")
+  )
+}
+
+#' Standardize OR BWN into the shared cross-state BWN schema
+#' @param config Main config
+#' @param dataset_id "clean_or_bwn"
+#' @param bwn_raw Optional pre-loaded raw BWN data. If NULL, downloaded from S3.
+run_clean_or_bwn_pipeline <- function(config, dataset_id = "clean_or_bwn",
+                                      bwn_raw = NULL) {
+  message(sprintf("Grabbing config variables for dataset %s...", dataset_id))
+  sub_config <- config[[dataset_id]]
+  raw_link <- sub_config$input_links$raw_link
+  link <- sub_config$link
+
+  if (is.null(bwn_raw)) {
+    message("Downloading raw OR BWN from S3...")
+    bwn_raw <- s3_read_csv(raw_link)
+  }
+
+  message("Standardizing to the shared BWN schema...")
+  or_bwn_clean <- bwn_raw %>%
+    # Renamed rather than copied, so the standardized columns land in the same
+    # positions the legacy worker left them in. Oregon's own rendering of the
+    # lift date is kept as or_date_lifted and the standardized column derived
+    # from it below.
+    rename(or_date_lifted = date_lifted,
+           type = advisory_type) %>%
+    mutate(date_issued = lubridate::mdy(begin_date),
+           begin_year = lubridate::year(date_issued),
+           date_lifted = lubridate::mdy(na_if(or_date_lifted, or_open_sentinel)),
+           lifted_year = lubridate::year(date_lifted),
+           last_epic_run_date = as.Date(last_epic_run_date,
+                                        tryFormats = c("%Y-%m-%d")),
+           # Oregon reports real lift dates
+           epic_date_lifted_flag = "Reported",
+           state = "Oregon") %>%
+    # advisory tracking began in May 2017. There is a single earlier record, and
+    # the first 2017 advisory is from 2017-05-08, so this cutoff is unambiguous.
+    filter(begin_year > 2016) %>%
+    finalize_bwn_clean()
+
+  message("Validating clean_or_bwn...")
+  validate_clean_bwn(config, or_bwn_clean, dataset_id,
+                     label = "OR BWN Clean Validation")
+
+  message(sprintf("Writing clean_or_bwn to S3 to %s...", link))
+  s3_write_csv(or_bwn_clean, link)
+
+  message(sprintf("%s pipeline completed successfully.", dataset_id))
+  return(or_bwn_clean)
+}

--- a/pipelines/pipeline_wa_bwn.R
+++ b/pipelines/pipeline_wa_bwn.R
@@ -1,0 +1,149 @@
+###############################################################################
+# Washington Boil Water Notices (issue #38)
+# Migrated from 1_downloaders/daily/wa_worker/wa_daily.R
+#
+# Washington DOH publishes an "active alerts" HTML table, so this is an active
+# feed: a record disappearing implies it was lifted and we date that closure to
+# the day we noticed it ("Assumed").
+#
+# The source publishes no system id, only a system name, so pwsid is recovered
+# by joining to the EPA SABs name list. That join is lossy (roughly a third of
+# rows match today), which is why the advisory itself is keyed on the system
+# NAME rather than pwsid, and why the pwsid completeness checks run at warning
+# severity here. An unmatched advisory is still a real advisory the national
+# summary has to count, so it is kept rather than filtered out.
+#
+# Shared BWN helpers live in functions/bwn_helpers.R.
+###############################################################################
+
+#' Pull Washington BWN data, then run the WA BWN clean pipeline
+#' @param config Main config
+#' @param dataset_id "raw_wa_bwn"
+run_wa_bwn_pipeline <- function(config, dataset_id) {
+  update_raw_wa_bwn(config, dataset_id)
+
+  message(sprintf("%s pipeline completed successfully.", dataset_id))
+}
+
+#' Fetch, reconcile against the previous run, validate, and save raw WA BWN data
+#' @param config Main config
+#' @param dataset_id "raw_wa_bwn"
+#' @return Reconciled raw BWN data frame
+update_raw_wa_bwn <- function(config, dataset_id) {
+  message(sprintf("Grabbing config variables for dataset %s...", dataset_id))
+  sub_config <- config[[dataset_id]]
+  source_url <- sub_config$source_url
+  link <- sub_config$link
+  pwsid_names_link <- sub_config$input_links$pwsid_names_link
+
+  message("Scraping the Washington DOH active alerts page...")
+  tables <- rvest::read_html(source_url) %>%
+    rvest::html_nodes("table") %>%
+    rvest::html_table(fill = TRUE)
+
+  if (length(tables) < 1) {
+    stop(sprintf(
+      "WA BWN: no alert table found on %s. The page layout has probably changed.",
+      source_url), call. = FALSE)
+  }
+
+  wa_bwn <- tables[[1]] %>%
+    janitor::clean_names() %>%
+    # "x" and "x_2" are unnamed layout columns in the published table. any_of()
+    # rather than a bare select so a cosmetic change to the page does not fail
+    # the run; a change to a column that actually matters is caught by the key
+    # check inside the reconcile.
+    select(-any_of(c("x", "x_2"))) %>%
+    # the table repeats a header-ish row with no system name
+    filter(!(is.na(water_system))) %>%
+    # normalized here because this doubles as the join key to the SABs name list
+    mutate(water_system = trimws(water_system),
+           water_system = str_to_title(water_system))
+
+  message("Recovering pwsids by system name from the EPA SABs name list...")
+  epa_sabs_pwsids <- s3_read_csv(pwsid_names_link)
+  wa_pwsids <- epa_sabs_pwsids %>% filter(grepl("WA", states_intersect))
+
+  wa_bwn_tidy <- merge(wa_bwn, wa_pwsids, by.x = "water_system",
+                       by.y = "pws_name", all.x = TRUE) %>%
+    relocate(pwsid) %>%
+    select(-any_of("states_intersect")) %>%
+    mutate(last_epic_run_date = as.character(Sys.Date()))
+
+  matched <- sum(!is.na(wa_bwn_tidy$pwsid))
+  message(sprintf("Matched %d of %d scraped advisories to a pwsid.",
+                  matched, nrow(wa_bwn_tidy)))
+
+  message("Reading the previous run for reconciliation...")
+  wa_bwn_old <- read_prior_bwn(link)
+
+  wa_bwn_reconciled <- reconcile_wa_bwn(wa_bwn_tidy, wa_bwn_old)
+
+  message("Validating raw_wa_bwn...")
+  validate_raw_bwn(config, wa_bwn_reconciled, wa_bwn_old, dataset_id,
+                   label = "WA Boil Water Notice Validation",
+                   pwsid_severity = "warning")
+
+  message(sprintf("Writing raw_wa_bwn to S3 to %s...", link))
+  s3_write_csv(wa_bwn_reconciled, link)
+
+  return(wa_bwn_reconciled)
+}
+
+#' Reconcile a fresh Washington pull against the previous run.
+#' Washington lists only active alerts, so this uses the shared active-feed
+#' reconcile. The advisory is identified by system name, issue date and the
+#' recommended action, because pwsid is missing for most rows and so cannot
+#' serve as the identity.
+#' @param wa_bwn_tidy Fresh pull, tidied
+#' @param wa_bwn_old Previous raw pull, or NULL on a first run
+#' @return Combined data frame
+reconcile_wa_bwn <- function(wa_bwn_tidy, wa_bwn_old) {
+  reconcile_bwn_active_feed(
+    wa_bwn_tidy, wa_bwn_old,
+    key_cols = c("water_system", "date_issued_sort_ascending",
+                 "action_recommended")
+  )
+}
+
+#' Standardize WA BWN into the shared cross-state BWN schema
+#' @param config Main config
+#' @param dataset_id "clean_wa_bwn"
+#' @param bwn_raw Optional pre-loaded raw BWN data. If NULL, downloaded from S3.
+run_clean_wa_bwn_pipeline <- function(config, dataset_id = "clean_wa_bwn",
+                                      bwn_raw = NULL) {
+  message(sprintf("Grabbing config variables for dataset %s...", dataset_id))
+  sub_config <- config[[dataset_id]]
+  raw_link <- sub_config$input_links$raw_link
+  link <- sub_config$link
+
+  if (is.null(bwn_raw)) {
+    message("Downloading raw WA BWN from S3...")
+    bwn_raw <- s3_read_csv(raw_link)
+  }
+
+  message("Standardizing to the shared BWN schema...")
+  wa_bwn_clean <- bwn_raw %>%
+    rename(date_issued = date_issued_sort_ascending,
+           type = action_recommended) %>%
+    mutate(date_issued = as.Date(date_issued, tryFormats = c("%m/%d/%Y")),
+           date_lifted = as.Date(date_lifted, tryFormats = c("%Y-%m-%d")),
+           last_epic_run_date = as.Date(last_epic_run_date,
+                                        tryFormats = c("%Y-%m-%d")),
+           # Washington publishes only active alerts, so every closure we record
+           # is inferred rather than reported. See the header note.
+           epic_date_lifted_flag = "Assumed",
+           state = "Washington") %>%
+    finalize_bwn_clean()
+
+  message("Validating clean_wa_bwn...")
+  validate_clean_bwn(config, wa_bwn_clean, dataset_id,
+                     label = "WA BWN Clean Validation",
+                     pwsid_severity = "warning")
+
+  message(sprintf("Writing clean_wa_bwn to S3 to %s...", link))
+  s3_write_csv(wa_bwn_clean, link)
+
+  message(sprintf("%s pipeline completed successfully.", dataset_id))
+  return(wa_bwn_clean)
+}


### PR DESCRIPTION
Migrates the last six BWN states for #38: **ME, WA, AR, OR, NM and FL**. These are the rvest ones, so each scrapes an HTML table rather than hitting an API.

Both reconcile families from #42 took them without changes, so each state is a set of key columns rather than another copy of the diff:

| | states | why |
|---|---|---|
| active feed | ME, WA | the page lists only advisories currently in effect, so one disappearing means it was lifted (`Assumed`) |
| rolling window | AR, OR, NM, FL | the page carries its own lift dates across a moving window, so aged-out records are retained from our history (`Reported`) |

## Questions for @christinetsai

1. **The national summary fix below.** It is your file and a one-word change, but it is the only thing here outside my own pipelines. Keep it in this PR, or pull it out?
2. **`drop_empty_scraped_rows` on Arkansas.** Florida genuinely needs it. Arkansas had no such guard at all, so applying it there is a small behavior change rather than a port. It can only drop a row where both the system name and the county are empty. Say if you would rather I left AR exactly as it was.
3. **Arkansas cadence.** Its worker sits under `daily/` but its header says quarterly. I set `update_freq` to daily.
4. **The name-matching gap, probably its own issue.** WA, AR, NM and FL publish no system id, so their workers recover the pwsid by matching names against `sabs_pwsid_names`. In prod that leaves Washington with 158 of 247 advisories unattached to a system, Arkansas 12 of 239, New Mexico 9 of 60. It predates this work, but happy to open a separate issue with the specifics.

## Florida, three departures from a literal port

1. Its page is header-only whenever no notice is active, which is its state right now. `html_table(fill = TRUE)` renders that as a single row of NAs, which the reconcile files as a real advisory with no system and no dates, and which then never ages out because its NA key keeps matching itself. The legacy guard against this only fired when the scrape returned exactly one new row, so `drop_empty_scraped_rows` keeps the intent and applies it to the scrape instead.
2. It never actually joined a pwsid, despite loading the SABs file, so every new notice was written with no system id. It now recovers one by name, the way WA, AR and NM do.
3. It could emit `epic_date_lifted_flag = "Assumed for this one record"`, which is outside the two values the summary contract allows, and that value is in the national summary in prod today. It maps to `"Assumed"`.

## One fix outside my files

`pipelines/pipeline_national_bwn_summary.R:66` calls `read_prior_merged_csv`, which is defined nowhere. The function it means is `read_existing_merged_csv`, at line 16 of the same file. Both names arrived in 48acaa9, so it looks like a rename that missed its call site. Every `clean_<state>_bwn` triggers the summary, so this has been aborting it for all states since Aug 13, not just the new ones. Fixed here because the six could not be tested end to end without it.

## Shared change

`pwsid_severity` on the two BWN validators, defaulting to `"stop"` so AK, WV, MO, TX and LA are untouched. The four name-matched states pass `"warning"`, since the strict check would otherwise abort every run (see question 4). Unmatched rows are kept rather than filtered, because an advisory with no pwsid is still one the summary counts.

## Verification

104 offline checks replay both legacy reconcile families against the shared helpers on the real prod baselines. All six then run through `main_runner.R --dev=TRUE` against dev copies of prod, with the full cascade into the summary.

No advisory lost in any state, and no contract-column difference except Florida's flag. Only the six migrated states move in the national summary. Prod was listed with ETags before the first run and after the last and is identical across all 374 objects.

<details>
<summary>Per-state row counts</summary>

| state | before | after |
|---|---|---|
| ME | 92 | 93 |
| WA | 247 | 247 |
| AR | 239 | 240 |
| OR | 1170 | 1196 |
| NM | 60 | 60 |
| FL | 1 | 1 |

AR, ME, OR and WA also gain rows in the national summary. Those are not new advisories, it is the summary catching up after not being re-rolled for those states in a while.

</details>

Two notes on things not in the diff. The twelve config entries are already live in `national-dw-tool/development/pipeline-config/main_config.json`, since the pipelines cannot run without them; `sync_main_config.R` reported no conflicts and the push was purely additive, though that object is also what prod runs read. Separately, the two crosswalk router entries added in 475c54b point at functions not yet in the repo, so `main_runner.R` will not start on `feature/reorg` head. Same as the nine back in July, so I commented them out locally to test and put them straight back.
